### PR TITLE
Fix/controller scope

### DIFF
--- a/controller/CompatibilityChecker.php
+++ b/controller/CompatibilityChecker.php
@@ -37,7 +37,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
      * @return mixed
      * @throws \common_ext_ExtensionException
      */
-    private function loadConfig()
+    protected function loadConfig()
     {
         return \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic')->getConfig('clientDiag');
     }
@@ -153,7 +153,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
      * @return array
      * @throws \common_exception_MissingParameter
      */
-    private function getData($check = false)
+    protected function getData($check = false)
     {
         $data = $this->getRequestParameters();
 
@@ -199,7 +199,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
      * Get cookie id OR create it if doesnt exist
      * @return string
      */
-    private function getId()
+    protected function getId()
     {
         if (!isset($_COOKIE['id'])) {
             $id = uniqid();

--- a/model/storage/Sql.php
+++ b/model/storage/Sql.php
@@ -97,7 +97,7 @@ class Sql extends ConfigurableService implements Storage
     protected function cleanInputData(array $input)
     {
         foreach ($input as $key => $value) {
-            $const = 'self::DIAGNOSTIC_' . strtoupper($key);
+            $const = get_called_class() . '::DIAGNOSTIC_' . strtoupper($key);
             if (defined($const)) {
                 $data[constant($const)] = $value;
             }

--- a/views/js/tools/diagnostic/diagnostic.js
+++ b/views/js/tools/diagnostic/diagnostic.js
@@ -125,7 +125,7 @@ define([
             details.type = type;
 
             $.post(
-                helpers._url(config.actionStore, config.controller, config.extension),
+                helpers._url(config.actionStore, config.controller, config.extension, config.storeParams),
                 details,
                 done,
                 "json"
@@ -145,7 +145,7 @@ define([
             browserTester(window, getConfig(this.config.browser, _defaultsBrowser)).start(function (information) {
                 // which browser
                 $.post(
-                    helpers._url(config.actionCheck, config.controller, config.extension),
+                    helpers._url(config.actionCheck, config.controller, config.extension, config.storeParams),
                     information,
                     function (data) {
                         var percentage = 'success' === data.type ? 100 : 0;
@@ -427,6 +427,7 @@ define([
      * @param {String} [config.actionCheck] - The name of the action to call to check the browser results
      * @param {String} [config.controller] - The name of the controller to call
      * @param {String} [config.extension] - The name of the extension containing the controller
+     * @param {Object} [config.storeParams] - A list of additional parameters to send with diagnostic results
      *
      * @param {String} [config.browser.action] - The name of the action to call to get the browser checker
      * @param {String} [config.browser.controller] - The name of the controller to call to get the browser checker


### PR DESCRIPTION
Change the scope of the controller's privates methods to protected to allow override.
Handles extra params on diagnostic storage queries.
