### PR TITLE
Update accepted chrome versions (48+) for chrome os

### DIFF
--- a/include/compatibility.json
+++ b/include/compatibility.json
@@ -15,10 +15,6 @@
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Chrome", "versions" : [39]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Safari", "versions" : [7]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Firefox", "versions" : []},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Chrome", "versions" : []},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Safari", "versions" : []},
-
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Chrome", "versions" : [39]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Safari", "versions" : []},
@@ -62,5 +58,4 @@
     {"compatible" : 1, "os" : "Android", "osVersion" : "4.4", "browser" : "Firefox", "versions" : [28]},
     {"compatible" : 1, "os" : "Android", "osVersion" : "4.1", "browser" : "Chrome", "versions" : [34]},
     {"compatible" : 1, "os" : "Android", "osVersion" : "2.4", "browser" : "", "versions" : []}
-
 ]

--- a/include/compatibility.json
+++ b/include/compatibility.json
@@ -45,7 +45,7 @@
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "Server2003", "browser" : "Firefox", "versions" : [34, 37, 40]},
 
-    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome", "versions" : [53]},
+    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome",  "versions" : [48, 49, 50, 51, 52, 53, 54, 55]},
 
     {"compatible" : 1, "os" : "iOS", "osVersion" : "10", "browser" : "Safari", "versions" : [10]},
     {"compatible" : 1, "os" : "iOS", "osVersion" : "9", "browser" : "Safari", "versions" : [9]},

--- a/include/compatibility.json
+++ b/include/compatibility.json
@@ -33,15 +33,15 @@
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 36, 40]},
     {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Chrome", "versions" : [33, 34, 35, 40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [10]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [10, 11]},
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Firefox", "versions" : [35]},
     {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [10]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [10, 11]},
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Firefox", "versions" : [34]},
     {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Chrome", "versions" : [40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [10]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [10, 11]},
     {"compatible" : 0, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [9]},
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Firefox", "versions" : [35]},

--- a/include/compatibility.json
+++ b/include/compatibility.json
@@ -1,51 +1,56 @@
 [
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Firefox", "versions" : [50]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Chrome", "versions" : [55]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Firefox", "versions" : [45]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Chrome", "versions" : [48]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Safari", "versions" : [10]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Firefox", "versions" : [40, 41, 42, 43, 44, 45]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Chrome", "versions" : [45, 46, 47, 48, 49]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Firefox", "versions" : [40]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Chrome", "versions" : [45]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Safari", "versions" : [9]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Firefox", "versions" : [34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Firefox", "versions" : [34]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Chrome", "versions" : [39]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Safari", "versions" : [8]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Chrome", "versions" : [39,40, 41, 42, 43, 44, 45, 46, 47, 48, 49]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Chrome", "versions" : [39]},
     {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Safari", "versions" : [7]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Chrome", "versions" : [39, 40, 41, 42, 42, 44, 45, 46, 47, 48, 49]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34, 35, 36, 37, 38, 39]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Chrome", "versions" : [39,40, 41, 42, 43, 44]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Firefox", "versions" : []},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Chrome", "versions" : []},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.8", "browser" : "Safari", "versions" : []},
 
-    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Chrome", "versions" : [39, 40, 41, 42, 43, 44]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Chrome", "versions" : [39]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Safari", "versions" : []},
+
+    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Chrome", "versions" : [39]},
     {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Firefox", "versions" : [31]},
 
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Firefox", "versions" : [40, 41, 42, 43, 44, 45, 50]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Chrome", "versions" : [45, 46, 47, 48, 55]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Firefox", "versions" : [40]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Chrome", "versions" : [45]},
     {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Internet Explorer", "versions" : [11]},
     {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Edge", "versions" : []},
 
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 36, 40, 41, 42, 43, 44, 45, 50]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Chrome", "versions" : [33, 34, 35, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 55]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [10,11]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 36, 40]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Chrome", "versions" : [33, 34, 35, 40]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [10]},
 
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Firefox", "versions" : [35,36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 50]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Chrome", "versions" : [39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 55]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [10,11]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Firefox", "versions" : [35]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Chrome", "versions" : [39]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [10]},
 
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Firefox", "versions" : [34,35,36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 50]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [10, 11]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Chrome", "versions" : [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 55]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Firefox", "versions" : [34]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Chrome", "versions" : [40]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [10]},
     {"compatible" : 0, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [9]},
 
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Firefox", "versions" : [35, 36]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Chrome", "versions" : [40, 41, 42, 43, 44]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Firefox", "versions" : [35]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Chrome", "versions" : [40]},
     {"compatible" : 0, "os" : "Windows", "osVersion" : "XP", "browser" : "Internet Explorer", "versions" : [8]},
 
     {"compatible" : 1, "os" : "Windows", "osVersion" : "Server2003", "browser" : "Firefox", "versions" : [34, 37, 40]},
 
-    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome",  "versions" : [48, 49, 50, 51, 52, 53, 54, 55]},
+    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome", "versions" : [48]},
 
     {"compatible" : 1, "os" : "iOS", "osVersion" : "10", "browser" : "Safari", "versions" : [10]},
     {"compatible" : 1, "os" : "iOS", "osVersion" : "9", "browser" : "Safari", "versions" : [9]},

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license' => 'GPL-2.0',
-    'version' => '1.11.2',
+    'version' => '1.11.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -324,6 +324,6 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         
-        $this->skip('1.10.2', '1.11.2');
+        $this->skip('1.10.2', '1.11.3');
     }
 }


### PR DESCRIPTION
Fix for https://oat-sa.atlassian.net/browse/TAO-3627

Note: it was asked to accept versions 45+ of firefox. I'm getting clarification on this right now if this was meant for Chrome OS (bc, as I currently understand it, chrome is the only acceptable browser on chrome os).