### PR TITLE
craete DiagnosticService

### DIFF
--- a/config/default/DiagnosticService.conf.php
+++ b/config/default/DiagnosticService.conf.php
@@ -1,0 +1,3 @@
+<?php
+
+return new oat\taoClientDiagnostic\model\diagnostic\DiagnosticService();

--- a/controller/Diagnostic.php
+++ b/controller/Diagnostic.php
@@ -26,7 +26,7 @@ use oat\tao\model\theme\ThemeService;
 use oat\taoClientDiagnostic\model\diagnostic\Paginator;
 use DateTime;
 use common_session_SessionManager as SessionManager;
-
+use oat\taoClientDiagnostic\model\diagnostic\DiagnosticServiceInterface;
 use oat\taoClientDiagnostic\model\diagnostic\DiagnosticDataTable;
 
 /**
@@ -190,7 +190,9 @@ class Diagnostic extends \tao_actions_CommonModule
      */
     protected function loadConfig()
     {
-        return \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic')->getConfig('clientDiag');
+        /** @var DiagnosticServiceInterface $service */
+        $service = $this->getServiceManager()->get(DiagnosticServiceInterface::SERVICE_ID);
+        return $service->getTesters();
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '2.3.0',
+    'version'     => '2.4.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=10.18.0',

--- a/model/diagnostic/DiagnosticService.php
+++ b/model/diagnostic/DiagnosticService.php
@@ -33,6 +33,6 @@ class DiagnosticService extends ConfigurableService implements DiagnosticService
      */
     public function getTesters()
     {
-        return \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic')->getConfig('clientDiag');
+        return $this->getServiceManager()->get('taoClientDiagnostic/clientDiag')->getConfig();
     }
 }

--- a/model/diagnostic/DiagnosticService.php
+++ b/model/diagnostic/DiagnosticService.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoClientDiagnostic\model\diagnostic;
+use oat\oatbox\service\ConfigurableService;
+/**
+ * Class DiagnosticService
+ * @package oat\taoClientDiagnostic\model\diagnostic
+ * @author Aleh Hutnikau, <hutnikau@apt.com>
+ */
+class DiagnosticService extends ConfigurableService implements DiagnosticServiceInterface
+{
+
+    /**
+     * @inheritdoc
+     */
+    public function getTesters()
+    {
+        return \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic')->getConfig('clientDiag');
+    }
+}

--- a/model/diagnostic/DiagnosticServiceInterface.php
+++ b/model/diagnostic/DiagnosticServiceInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoClientDiagnostic\model\diagnostic;
+
+/**
+ * Interface DiagnosticServiceInterface
+ * @package oat\taoClientDiagnostic\model\diagnostic
+ */
+interface DiagnosticServiceInterface
+{
+    const SERVICE_ID = 'taoClientDiagnostic/DiagnosticService';
+
+    /**
+     * Returns list of tester
+     * @return array
+     */
+    public function getTesters();
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -35,6 +35,7 @@ use oat\taoClientDiagnostic\model\storage\PaginatedSqlStorage;
 use oat\taoClientDiagnostic\model\storage\PaginatedStorage;
 use oat\taoClientDiagnostic\model\storage\Sql;
 use oat\taoClientDiagnostic\model\storage\Storage;
+use oat\taoClientDiagnostic\model\diagnostic\DiagnosticService;
 
 class Updater extends \common_ext_ExtensionUpdater
 {
@@ -464,5 +465,10 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('2.2.0', '2.3.0');
+
+        if ($this->isVersion('2.3.0')) {
+            $this->getServiceManager()->register(DiagnosticService::SERVICE_ID, new DiagnosticService());
+            $this->setVersion('2.4.0');
+        }
     }
 }


### PR DESCRIPTION
`DiagnosticService` will be replaced in ACT extension to be able to return the list of testers based on given LTI options