### PR TITLE
Record Information Via Get

### DIFF
--- a/config/default/clientDiag.conf.php
+++ b/config/default/clientDiag.conf.php
@@ -58,6 +58,14 @@ return array(
     'requireSchoolName' => false,
 
     /**
+     * An array describing how GET parameters in use when invoking the Diagnostic Tool should be transferred
+     * to the server side for storage. Keys describe the GET parameter names, and values describe the name of the
+     * data to be sent to the server side.
+     * @type array
+     */
+    'customInput' => [],
+
+    /**
      * List of testers that can be loaded
      * @type array
      */
@@ -320,6 +328,6 @@ return array(
              * @type string
              */
             'customMsgKey' => 'diagFingerprintCheckResult',
-        ],
+        ]
     ]
 );

--- a/controller/CompatibilityChecker.php
+++ b/controller/CompatibilityChecker.php
@@ -301,7 +301,6 @@ class CompatibilityChecker extends \tao_actions_CommonModule
             }
         }
 
-        \common_Logger::i(var_export($data, true));
         return $data;
     }
 }

--- a/controller/CompatibilityChecker.php
+++ b/controller/CompatibilityChecker.php
@@ -290,6 +290,12 @@ class CompatibilityChecker extends \tao_actions_CommonModule
         return $config;
     }
 
+    /**
+     * Map custom input data from the 'customInput' configuration.
+     *
+     * @param array $data
+     * @return array
+     */
     protected function mapData(array $data) {
         $config = $this->loadConfig();
 

--- a/controller/CompatibilityChecker.php
+++ b/controller/CompatibilityChecker.php
@@ -28,7 +28,6 @@ use oat\taoClientDiagnostic\model\diagnostic\DiagnosticServiceInterface;
 use oat\taoClientDiagnostic\model\storage\Storage;
 use oat\taoClientDiagnostic\model\browserDetector\WebBrowserService;
 use oat\taoClientDiagnostic\model\browserDetector\OSService;
-use qtism\runtime\tests\SessionManager;
 
 /**
  * Class CompatibilityChecker

--- a/controller/CompatibilityChecker.php
+++ b/controller/CompatibilityChecker.php
@@ -45,7 +45,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
      */
     public function index()
     {
-        $authorizationService = $this->getServiceManager()->get(Authorization::SERVICE_ID);
+        $authorizationService = $this->getServiceLocator()->get(Authorization::SERVICE_ID);
         if ($authorizationService->isAuthorized()) {
 
             $config = $this->loadConfig();
@@ -56,7 +56,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
 
             $this->setData('client-config-url', $this->getClientConfigUrl());
             $this->setData('content-config', $config);
-            $this->setData('logout', $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID)->getLogoutUrl());
+            $this->setData('logout', $this->getServiceLocator()->get(DefaultUrlService::SERVICE_ID)->getLogoutUrl());
             $this->setData('content-controller', 'taoClientDiagnostic/controller/CompatibilityChecker/diagnostics');
             $this->setData('content-template', 'CompatibilityChecker' . DIRECTORY_SEPARATOR . 'diagnostics.tpl');
             $this->setView('index.tpl');
@@ -98,7 +98,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
             $data['compatible'] = $isCompatible;
 
             try {
-                $storageService = $this->getServiceManager()->get(Storage::SERVICE_ID);
+                $storageService = $this->getServiceLocator()->get(Storage::SERVICE_ID);
                 $storageService->store($id, $data);
             } catch (StorageException $e) {
                 \common_Logger::i($e->getMessage());
@@ -168,7 +168,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
         $id   = $this->getId();
 
         try {
-            $storageService = $this->getServiceManager()->get(Storage::SERVICE_ID);
+            $storageService = $this->getServiceLocator()->get(Storage::SERVICE_ID);
             $storageService->store($id, $data);
             $this->returnJson(array('success' => true, 'type' => 'success'));
         } catch (StorageException $e) {
@@ -193,12 +193,17 @@ class CompatibilityChecker extends \tao_actions_CommonModule
 
         if ($this->hasRequestParameter('type')) {
             $type = $this->getRequestParameter('type');
-            foreach ($data as $key => $value) {
-                $data[$type . '_' . $key] = $value;
-                unset($data[$key]);
+            unset($data['type']);
+
+            if ($type !== 'custom_input') {
+                foreach ($data as $key => $value) {
+                    $data[$type . '_' . $key] = $value;
+                    unset($data[$key]);
+                }
             }
-            unset($data[$type . '_type']);
         }
+
+        $data = $this->mapData($data);
 
         if ($this->hasRequestParameter('school')) {
             $data[Storage::DIAGNOSTIC_SCHOOL] = \tao_helpers_Display::sanitizeXssHtml(trim($this->getRequestParameter('school')));
@@ -232,7 +237,7 @@ class CompatibilityChecker extends \tao_actions_CommonModule
             $data['user_id'] = $user->getIdentifier();
         }
 
-        $data['version'] = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic')->getVersion();
+        $data['version'] = $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic')->getVersion();
 
         $data['ip'] = (!empty($_SERVER['HTTP_X_REAL_IP'])) ? $_SERVER['HTTP_X_REAL_IP'] : ((!empty($_SERVER['REMOTE_ADDR'])) ? $_SERVER['REMOTE_ADDR'] : 'unknown');
         return $data;
@@ -276,14 +281,27 @@ class CompatibilityChecker extends \tao_actions_CommonModule
      * Get config parameters for compatibility check
      *
      * @return mixed
-     * @throws \common_ext_ExtensionException
      */
     protected function loadConfig()
     {
         /** @var DiagnosticServiceInterface $service */
-        $service = $this->getServiceManager()->get(DiagnosticServiceInterface::SERVICE_ID);
-        $config = $service->getTesters();
+        $service = $this->getServiceLocator()->get(DiagnosticServiceInterface::SERVICE_ID);
+        $config = $service->getDiagnosticJsConfig();
         $config['controller'] = 'CompatibilityChecker';
         return $config;
+    }
+
+    protected function mapData(array $data) {
+        $config = $this->loadConfig();
+
+        foreach ($data as $k => $d) {
+            if (!empty($config['customInput'][$k])) {
+                $data[$config['customInput'][$k]] = $d;
+                unset($data[$k]);
+            }
+        }
+
+        \common_Logger::i(var_export($data, true));
+        return $data;
     }
 }

--- a/controller/Diagnostic.php
+++ b/controller/Diagnostic.php
@@ -88,7 +88,8 @@ class Diagnostic extends \tao_actions_CommonModule
         $this->setData('data', $data);
         $this->setData('content-template', 'pages/index.tpl');
 
-        $themeService = $this->getServiceManager()->get(ThemeService::SERVICE_ID);
+        /** @var \oat\tao\model\theme\ThemeService $themeService */
+        $themeService = $this->getServiceLocator()->get(ThemeService::SERVICE_ID);
         $theme = $themeService->getTheme();
         $configurableText = $theme->getAllTexts();
         $this->setData('configurableText', json_encode($configurableText));
@@ -179,13 +180,12 @@ class Diagnostic extends \tao_actions_CommonModule
      * Get config parameters for compatibility check
      *
      * @return mixed
-     * @throws \common_ext_ExtensionException
      */
     protected function loadConfig()
     {
         /** @var DiagnosticServiceInterface $service */
-        $service = $this->getServiceManager()->get(DiagnosticServiceInterface::SERVICE_ID);
-        return $service->getTesters();
+        $service = $this->getServiceLocator()->get(DiagnosticServiceInterface::SERVICE_ID);
+        return $service->getDiagnosticJsConfig();
     }
 
     /**
@@ -197,7 +197,7 @@ class Diagnostic extends \tao_actions_CommonModule
     {
         if (! $this->dataTable) {
             $diagnosticDatatable = new DiagnosticDataTable();
-            $diagnosticDatatable->setServiceLocator($this->getServiceManager());
+            $diagnosticDatatable->setServiceLocator($this->getServiceLocator());
             $this->dataTable = $diagnosticDatatable;
         }
         return $this->dataTable;

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '2.11.0',
+    'version'     => '2.12.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=14.3.1',

--- a/model/diagnostic/DiagnosticService.php
+++ b/model/diagnostic/DiagnosticService.php
@@ -35,7 +35,7 @@ class DiagnosticService extends ConfigurableService implements DiagnosticService
     public function getDiagnosticJsConfig()
     {
         $config = $this->getRawConfig();
-        // override samples based on grafical theme, why not
+        // override samples based on graphical theme, why not
         $config['testers']['performance']['samples'] = $this->getPerformanceSamples();
         return $config;
     }

--- a/scripts/config/AddCustomInputMappingEntry.php
+++ b/scripts/config/AddCustomInputMappingEntry.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoClientDiagnostic\scripts\config;
+
+use oat\oatbox\extension\InstallAction;
+use \common_report_Report as Report;
+
+/**
+ * Class AddCustomInputMappingEntry
+ * @package oat\taoClientDiagnostic\scripts\config
+ */
+class AddCustomInputMappingEntry extends InstallAction
+{
+    /**
+     * @param $params
+     * @return \common_report_Report
+     */
+    public function __invoke($params)
+    {
+        if (empty($params[0])) {
+            return new Report(Report::TYPE_ERROR, "Missing argument 'key'.");
+        } elseif (empty($params[1])) {
+            return new Report(Report::TYPE_ERROR, "Missing argument 'mapping'");
+        }
+
+        $key = $params[0];
+        $mapping = $params[1];
+
+        $extension = $this->getServiceLocator()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
+        $config = $extension->getConfig('clientDiag');
+
+        $config['customInput'][$key] = $mapping;
+
+        $extension->setConfig('clientDiag', $config);
+
+        return new Report(Report::TYPE_SUCCESS, "Mapping '${key}':'${mapping}' successfully registered.");
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -124,7 +124,6 @@ class Updater extends \common_ext_ExtensionUpdater
 
             if (!$this->getServiceManager()->has(Authorization::SERVICE_ID)) {
                 $service = new RequireUsername();
-                $this->getServiceManager()->propagate($service);
                 $this->getServiceManager()->register(Authorization::SERVICE_ID, $service);
             }
 
@@ -138,7 +137,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 $service = new RequireUsername(array(
                     'regexValidator' => '/^[0-9]{7}[A-Z]$/'
                 ));
-                $this->getServiceManager()->propagate($service);
+
                 $this->getServiceManager()->register(Authorization::SERVICE_ID, $service);
             }
 
@@ -150,7 +149,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 $service = new Csv(array(
                     'filename' => FILES_PATH . 'taoClientDiagnostic' . DIRECTORY_SEPARATOR . 'storage' . DIRECTORY_SEPARATOR . 'store.csv'
                 ));
-                $this->getServiceManager()->propagate($service);
+                
                 $this->getServiceManager()->register(Storage::SERVICE_ID, $service);
             }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -607,5 +607,14 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('2.11.0');
         }
+
+        if ($this->isVersion('2.11.0')) {
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
+            $config = $extension->getConfig('clientDiag');
+            $config['customInput'] = [];
+            $extension->setConfig('clientDiag', $config);
+
+            $this->setVersion('2.12.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -149,7 +149,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 $service = new Csv(array(
                     'filename' => FILES_PATH . 'taoClientDiagnostic' . DIRECTORY_SEPARATOR . 'storage' . DIRECTORY_SEPARATOR . 'store.csv'
                 ));
-                
+
                 $this->getServiceManager()->register(Storage::SERVICE_ID, $service);
             }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -70,7 +70,7 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         if ($currentVersion == '1.1.1') {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $extension->setConfig('clientDiag', array(
                 'footer' => '',
             ));
@@ -79,7 +79,7 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         if ($currentVersion == '1.2.0') {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
             $extension->setConfig('clientDiag', array_merge($config, array(
                 'performances' => array(
@@ -106,7 +106,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->setVersion($currentVersion);
 
         if($this->isVersion('1.3.0')) {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
             $extension->setConfig('clientDiag', array_merge($config, array(
                 'diagHeader' => 'This tool will run a number of tests in order to establish how well your current environment is suitable to run the TAO platform.',
@@ -124,7 +124,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
             if (!$this->getServiceManager()->has(Authorization::SERVICE_ID)) {
                 $service = new RequireUsername();
-                $service->setServiceManager($this->getServiceManager());
+                $this->getServiceManager()->propagate($service);
                 $this->getServiceManager()->register(Authorization::SERVICE_ID, $service);
             }
 
@@ -138,7 +138,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 $service = new RequireUsername(array(
                     'regexValidator' => '/^[0-9]{7}[A-Z]$/'
                 ));
-                $service->setServiceManager($this->getServiceManager());
+                $this->getServiceManager()->propagate($service);
                 $this->getServiceManager()->register(Authorization::SERVICE_ID, $service);
             }
 
@@ -150,7 +150,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 $service = new Csv(array(
                     'filename' => FILES_PATH . 'taoClientDiagnostic' . DIRECTORY_SEPARATOR . 'storage' . DIRECTORY_SEPARATOR . 'store.csv'
                 ));
-                $service->setServiceManager($this->getServiceManager());
+                $this->getServiceManager()->propagate($service);
                 $this->getServiceManager()->register(Storage::SERVICE_ID, $service);
             }
 
@@ -299,7 +299,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('1.7.1', '1.9.1');
 
         if ($this->isVersion('1.9.1')) {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
             $config['upload'] =[
                 'size' => 1 * 1024 * 1024,
@@ -410,7 +410,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('1.15.0', '2.0.1');
 
         if ($this->isVersion('2.0.1')) {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
             $newConfig = [
                 'diagHeader' => $config['diagHeader'],
@@ -474,7 +474,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('2.4.0', '2.6.1');
 
         if ($this->isVersion('2.6.1')) {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
 
             if (isset($config['testers'])) {
@@ -529,7 +529,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('2.7.0', '2.8.1');
 
         if ($this->isVersion('2.8.1')) {
-            $extension = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoClientDiagnostic');
+            $extension = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('taoClientDiagnostic');
             $config = $extension->getConfig('clientDiag');
 
             $config['testers']['performance']['customMsgKey'] = 'diagPerformancesCheckResult';

--- a/views/js/tools/diagnostic/diagnostic.js
+++ b/views/js/tools/diagnostic/diagnostic.js
@@ -403,7 +403,7 @@ define([
                 /[?&]+([^=&]+)=?([^&]*)?/gi,
                 function (m, key, value) {
                     if (_.has(self.config['customInput'], key)) {
-                        vars[key] = value !== undefined ? value : '';
+                        vars[key] = typeof value !== 'undefined' ? value : '';
                     }
                 }
             );

--- a/views/js/tools/diagnostic/diagnostic.js
+++ b/views/js/tools/diagnostic/diagnostic.js
@@ -293,97 +293,122 @@ define([
             var information = [];
             var scores = {};
             var testers = [];
+            var customInput = self.getCustomInput();
 
-            // common handling for testers
-            function doCheck(testerConfig, cb) {
-                var testerId = testerConfig.id;
+            var doRun = function() {
+                // common handling for testers
+                function doCheck(testerConfig, cb) {
+                    var testerId = testerConfig.id;
 
-                /**
-                 * Notifies the start of a tester operation
-                 * @event diagnostic#starttester
-                 * @param {String} name - The name of the tester
-                 */
-                self.trigger('starttester', testerId);
-                self.setState(testerId, true);
+                    /**
+                     * Notifies the start of a tester operation
+                     * @event diagnostic#starttester
+                     * @param {String} name - The name of the tester
+                     */
+                    self.trigger('starttester', testerId);
+                    self.setState(testerId, true);
 
-                require([testerConfig.tester], function (testerFactory){
-                    var tester = testerFactory(getConfig(testerConfig, self.config), self);
-                    self.changeStatus(tester.labels.status);
-                    tester.start(function (status, details, results) {
-                        var customMsg;
-                        if (testerConfig.customMsgKey) {
-                            customMsg = self.getCustomMsg(testerConfig.customMsgKey);
-                            self.addCustomFeedbackMsg(status, customMsg);
-                        }
-
-                        // the returned details must be ingested into the main details list
-                        _.forEach(details, function(info) {
-                            information.push(info);
-                        });
-                        scores[status.id] = status;
-
-                        /**
-                         * Notifies the end of a tester operation
-                         * @event diagnostic#endtester
-                         * @param {String} id - The identifier of the tester
-                         * @param {Array} results - The results of the test
-                         */
-                        self.trigger('endtester', testerId, status);
-                        self.setState(testerId, false);
-
-                        // results should be filtered in order to encode complex data
-                        results = _.mapValues(results, function(value) {
-                            switch(typeof(value)) {
-                                case 'boolean': return value ? 1 : 0;
-                                case 'object': return JSON.stringify(value);
+                    require([testerConfig.tester], function (testerFactory){
+                        var tester = testerFactory(getConfig(testerConfig, self.config), self);
+                        self.changeStatus(tester.labels.status);
+                        tester.start(function (status, details, results) {
+                            var customMsg;
+                            if (testerConfig.customMsgKey) {
+                                customMsg = self.getCustomMsg(testerConfig.customMsgKey);
+                                self.addCustomFeedbackMsg(status, customMsg);
                             }
-                            return value;
-                        });
 
-                        // send the data to store
-                        self.store(testerId, results, function () {
-                            self.addResult(status);
-                            cb();
+                            // the returned details must be ingested into the main details list
+                            _.forEach(details, function(info) {
+                                information.push(info);
+                            });
+                            scores[status.id] = status;
+
+                            /**
+                             * Notifies the end of a tester operation
+                             * @event diagnostic#endtester
+                             * @param {String} id - The identifier of the tester
+                             * @param {Array} results - The results of the test
+                             */
+                            self.trigger('endtester', testerId, status);
+                            self.setState(testerId, false);
+
+                            // results should be filtered in order to encode complex data
+                            results = _.mapValues(results, function(value) {
+                                switch(typeof(value)) {
+                                    case 'boolean': return value ? 1 : 0;
+                                    case 'object': return JSON.stringify(value);
+                                }
+                                return value;
+                            });
+
+                            // send the data to store
+                            self.store(testerId, results, function () {
+                                self.addResult(status);
+                                cb();
+                            });
                         });
                     });
-                });
+                }
+
+                if (self.is('rendered')) {
+                    // set up the component to a new run
+                    self.prepare();
+
+                    _.forEach(self.config.testers, function(testerConfig, testerId) {
+                        testerConfig.id = testerConfig.id || testerId;
+                        if (testerConfig.enabled) {
+                            testers.push(function (cb) {
+                                doCheck(testerConfig, cb);
+                            });
+                        }
+                    });
+
+                    // launch each testers in series, then display the results
+                    async.series(testers, function () {
+                        // pick the lowest percentage as the main score
+                        var total = _.min(scores, 'percentage');
+
+                        // get a status according to the main score
+                        var status = getStatus(total.percentage, _thresholds);
+
+                        // display the result
+                        status.title = __('Total');
+                        status.id = 'total';
+                        self.addCustomFeedbackMsg(status, self.config.configurableText.diagTotalCheckResult);
+
+                        status.details = information;
+                        self.addResult(status);
+
+                        // done !
+                        self.finish();
+                    });
+                }
+
+                return self;
+            };
+
+            if (_.size(customInput) > 0) {
+                self.store('custom_input', customInput, doRun);
+            } else {
+                doRun();
             }
+        },
 
-            if (this.is('rendered')) {
-                // set up the component to a new run
-                this.prepare();
+        getCustomInput: function() {
+            var vars = {};
+            var self = this;
 
-                _.forEach(this.config.testers, function(testerConfig, testerId) {
-                    testerConfig.id = testerConfig.id || testerId;
-                    if (testerConfig.enabled) {
-                        testers.push(function (cb) {
-                            doCheck(testerConfig, cb);
-                        });
+            window.location.href.replace(location.hash, '').replace(
+                /[?&]+([^=&]+)=?([^&]*)?/gi,
+                function (m, key, value) {
+                    if (_.has(self.config['customInput'], key)) {
+                        vars[key] = value !== undefined ? value : '';
                     }
-                });
+                }
+            );
 
-                // launch each testers in series, then display the results
-                async.series(testers, function () {
-                    // pick the lowest percentage as the main score
-                    var total = _.min(scores, 'percentage');
-
-                    // get a status according to the main score
-                    var status = getStatus(total.percentage, _thresholds);
-
-                    // display the result
-                    status.title = __('Total');
-                    status.id = 'total';
-                    self.addCustomFeedbackMsg(status, self.config.configurableText.diagTotalCheckResult);
-
-                    status.details = information;
-                    self.addResult(status);
-
-                    // done !
-                    self.finish();
-                });
-            }
-
-            return this;
+            return vars;
         }
     };
 

--- a/views/js/tools/diagnostic/diagnostic.js
+++ b/views/js/tools/diagnostic/diagnostic.js
@@ -384,8 +384,6 @@ define([
                         self.finish();
                     });
                 }
-
-                return self;
             };
 
             if (_.size(customInput) > 0) {
@@ -393,6 +391,8 @@ define([
             } else {
                 doRun();
             }
+
+            return self;
         },
 
         getCustomInput: function() {


### PR DESCRIPTION
The goal of this PR is to be able to transmit some information passed via GET parameters to the RDBMS storage (see table diagnostic_report) when taking the diagnostic tool.

Example, in case of the diagnostic tool, in anonymous mode is invoked via URL `http://taoplatform/taoClientDiagnostic/CompatibilityChecker/index?my-context=custom` and want to store the `my-context` value in the `context_id` field of the `diagnostic_report` table, I have to configure the taoClientDiagnostic tool with the following command:

```
sudo -u www-data php index.php "oat\taoClientDiagnostic\scripts\config\AddCustomInputMappingEntry" my-context context_id
```