### PR TITLE
Fix/tao 5902 diagnostic tool broken

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '2.17.2',
+    'version'     => '2.17.3',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=17.8.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -713,6 +713,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.15.0');
         }
 
-        $this->skip('2.15.0', '2.17.2');
+        $this->skip('2.15.0', '2.17.3');
     }
 }

--- a/views/js/tools/bandwidth/tester.js
+++ b/views/js/tools/bandwidth/tester.js
@@ -228,6 +228,11 @@ define([
         var initConfig = getConfig(config, _defaults);
         var labels = getLabels(_messages, initConfig.level);
 
+        // override the feedback thresholds given by the config in case it is an empty array
+        if (_.isArray(initConfig.feedbackThresholds) && !initConfig.feedbackThresholds.length) {
+            initConfig.feedbackThresholds = _thresholds;
+        }
+
         return {
             /**
              * Performs a bandwidth test, then call a function to provide the result


### PR DESCRIPTION
Fix a regression introduced by TAO-5902

On an instance without the Depp extension:
- Go to /taoClientDiagnostic/CompatibilityChecker/index
- Start the diagnostic tool
- without this fix, the tool breaks during the bandwith test. That's because the test in runs without any thresholds, as the default configuration gives an empty array
