### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '4.0.0',
+    'version'     => '4.0.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=21.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,10 +29,10 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '4.0.1',
+    'version'     => '4.1.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
-        'tao'        => '>=21.0.0',
+        'tao'        => '>=30.0.0',
         'taoQtiItem' => '>=18.0.0',
     ),
     // for compatibility

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -727,6 +727,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.17.9');
         }
 
-        $this->skip('2.17.9', '4.0.1');
+        $this->skip('2.17.9', '4.1.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -727,6 +727,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.17.9');
         }
 
-        $this->skip('2.17.9', '4.0.0');
+        $this->skip('2.17.9', '4.0.1');
     }
 }

--- a/views/js/test/tools/bandwidth/test.html
+++ b/views/js/test/tools/bandwidth/test.html
@@ -5,8 +5,8 @@
         <title>Test - Bandwidth Tester</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/bandwidth/tester"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/bandwidth/test.js
+++ b/views/js/test/tools/bandwidth/test.js
@@ -15,25 +15,22 @@
  *
  * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA ;
  */
-define([
-    'context',
-    'taoClientDiagnostic/tools/bandwidth/tester',
-], function(context, bandwidthTester){
+define( [  'context', 'taoClientDiagnostic/tools/bandwidth/tester' ], function(  context, bandwidthTester ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function(assert){
-        QUnit.expect(6);
-        assert.ok(typeof bandwidthTester === 'function', 'The module exposes a function');
-        assert.ok(typeof bandwidthTester() === 'object', 'bandwidthTester is a factory');
-        assert.ok(typeof bandwidthTester().start === 'function', 'the test has a start method');
-        assert.ok(typeof bandwidthTester().getSummary === 'function', 'the test has a getSummary method');
-        assert.ok(typeof bandwidthTester().getFeedback === 'function', 'the test has a getFeedback method');
-        assert.ok(typeof bandwidthTester().labels === 'object', 'the test has a labels objects');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.expect( 6 );
+        assert.ok( typeof bandwidthTester === 'function', 'The module exposes a function' );
+        assert.ok( typeof bandwidthTester() === 'object', 'bandwidthTester is a factory' );
+        assert.ok( typeof bandwidthTester().start === 'function', 'the test has a start method' );
+        assert.ok( typeof bandwidthTester().getSummary === 'function', 'the test has a getSummary method' );
+        assert.ok( typeof bandwidthTester().getFeedback === 'function', 'the test has a getFeedback method' );
+        assert.ok( typeof bandwidthTester().labels === 'object', 'the test has a labels objects' );
+    } );
 
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no level'
     }, {
         title: 'level 0',
@@ -47,9 +44,9 @@ define([
     }, {
         title: 'level 3',
         level: 3
-    }])
-        .test('labels', function(data, assert) {
-            var labels = bandwidthTester({level: data.level}).labels;
+    } ] )
+        .test( 'labels', function( data, assert ) {
+            var labels = bandwidthTester( { level: data.level } ).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -59,86 +56,86 @@ define([
                 'bandwidthAverage'
             ];
 
-            QUnit.expect(labelKeys.length + 1);
+            assert.expect( labelKeys.length + 1 );
 
-            assert.equal(typeof labels, 'object', 'A set of labels is returned');
-            labelKeys.forEach(function(key) {
-                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
-            });
-        });
+            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
+            labelKeys.forEach( function( key ) {
+                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
+            } );
+        } );
 
-    QUnit.test('getSummary', function(assert) {
-        var tester = bandwidthTester({});
+    QUnit.test( 'getSummary', function( assert ) {
+        var tester = bandwidthTester( {} );
         var results = {
             min: 30,
             max: 90,
             average: 60
         };
-        var summary = tester.getSummary(results);
+        var summary = tester.getSummary( results );
 
-        QUnit.expect(10);
+        assert.expect( 10 );
 
-        assert.equal(typeof summary, 'object', 'The method has returned the summary');
+        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
 
-        assert.equal(typeof summary.bandwidthMin, 'object', 'The summary contains entry for min bandwidth');
-        assert.equal(typeof summary.bandwidthMin.message, 'string', 'The summary contains label for min bandwidth');
-        assert.equal(summary.bandwidthMin.value, results.min + ' Mbps', 'The summary contains the expected value for min bandwidth');
+        assert.equal( typeof summary.bandwidthMin, 'object', 'The summary contains entry for min bandwidth' );
+        assert.equal( typeof summary.bandwidthMin.message, 'string', 'The summary contains label for min bandwidth' );
+        assert.equal( summary.bandwidthMin.value, results.min + ' Mbps', 'The summary contains the expected value for min bandwidth' );
 
-        assert.equal(typeof summary.bandwidthMax, 'object', 'The summary contains entry for max bandwidth');
-        assert.equal(typeof summary.bandwidthMax.message, 'string', 'The summary contains label for max bandwidth');
-        assert.equal(summary.bandwidthMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth');
+        assert.equal( typeof summary.bandwidthMax, 'object', 'The summary contains entry for max bandwidth' );
+        assert.equal( typeof summary.bandwidthMax.message, 'string', 'The summary contains label for max bandwidth' );
+        assert.equal( summary.bandwidthMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth' );
 
-        assert.equal(typeof summary.bandwidthAverage, 'object', 'The summary contains entry for average bandwidth');
-        assert.equal(typeof summary.bandwidthAverage.message, 'string', 'The summary contains label for average bandwidth');
-        assert.equal(summary.bandwidthAverage.value, results.average + ' Mbps', 'The summary contains the expected value for average bandwidth');
-    });
+        assert.equal( typeof summary.bandwidthAverage, 'object', 'The summary contains entry for average bandwidth' );
+        assert.equal( typeof summary.bandwidthAverage.message, 'string', 'The summary contains label for average bandwidth' );
+        assert.equal( summary.bandwidthAverage.value, results.average + ' Mbps', 'The summary contains the expected value for average bandwidth' );
+    } );
 
-    QUnit.test('getFeedback', function(assert) {
-        var tester = bandwidthTester({});
-        var result = {max: 100, min: 10, average: 55};
-        var status = tester.getFeedback(result);
+    QUnit.test( 'getFeedback', function( assert ) {
+        var tester = bandwidthTester( {} );
+        var result = { max: 100, min: 10, average: 55 };
+        var status = tester.getFeedback( result );
 
-        QUnit.expect(6);
+        assert.expect( 6 );
 
-        assert.equal(typeof status, 'object', 'The method has returned the status');
-        assert.equal(status.id, 'bandwidth', 'The status contains the tester id');
-        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
-        assert.equal(typeof status.title, 'string', 'The status contains a title');
-        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
-        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
-    });
+        assert.equal( typeof status, 'object', 'The method has returned the status' );
+        assert.equal( status.id, 'bandwidth', 'The status contains the tester id' );
+        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
+        assert.equal( typeof status.title, 'string', 'The status contains a title' );
+        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
+        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
+    } );
 
-    QUnit.module('Test');
+    QUnit.module( 'Test' );
 
-    QUnit.asyncTest('The tester runs', function(assert){
+    QUnit.test( 'The tester runs', function( assert ) {
+        var ready = assert.async();
 
-        QUnit.expect(13);
+        assert.expect( 13 );
 
-        // override root_url to be able to download the files during unit tests
+        // Override root_url to be able to download the files during unit tests
         context.root_url = '../../';
 
-        bandwidthTester({}).start(function(status, details, results){
+        bandwidthTester( {} ).start( function( status, details, results ) {
 
             var toString = {}.toString;
             var speed = results.average;
 
-            assert.ok(typeof status === 'object', 'The status is a object');
-            assert.ok(typeof details === 'object', 'The details is a object');
-            assert.ok(typeof results === 'object', 'The results is a object');
-            assert.ok(speed > 0, 'The result is a positive number');
-            assert.ok(typeof results === 'object', 'The details are provided inside an object');
-            assert.ok(typeof results.min === 'number', 'The minimum speed is provided inside the details');
-            assert.ok(typeof results.max === 'number', 'The maximum speed is provided inside the details');
-            assert.ok(typeof results.average === 'number', 'The average speed is provided inside the details');
-            assert.ok(typeof results.variance === 'number', 'The speed variance is provided inside the details');
-            assert.ok(typeof results.duration === 'number', 'The total duration of the test is provided inside the details');
-            assert.ok(typeof results.size === 'number', 'The total size of the test is provided inside the details');
-            assert.equal(speed, results.average, 'The speed provided inside the details must be equal to provided speed');
-            assert.ok(toString.call(results.values) === '[object Array]', 'The detailed measures are provided inside the details');
+            assert.ok( typeof status === 'object', 'The status is a object' );
+            assert.ok( typeof details === 'object', 'The details is a object' );
+            assert.ok( typeof results === 'object', 'The results is a object' );
+            assert.ok( speed > 0, 'The result is a positive number' );
+            assert.ok( typeof results === 'object', 'The details are provided inside an object' );
+            assert.ok( typeof results.min === 'number', 'The minimum speed is provided inside the details' );
+            assert.ok( typeof results.max === 'number', 'The maximum speed is provided inside the details' );
+            assert.ok( typeof results.average === 'number', 'The average speed is provided inside the details' );
+            assert.ok( typeof results.variance === 'number', 'The speed variance is provided inside the details' );
+            assert.ok( typeof results.duration === 'number', 'The total duration of the test is provided inside the details' );
+            assert.ok( typeof results.size === 'number', 'The total size of the test is provided inside the details' );
+            assert.equal( speed, results.average, 'The speed provided inside the details must be equal to provided speed' );
+            assert.ok(toString.call( results.values ) === '[object Array]', 'The detailed measures are provided inside the details' );
 
-            QUnit.start();
-        });
+            ready();
+        } );
+    } );
 
-    });
-
-});
+} );

--- a/views/js/test/tools/bandwidth/test.js
+++ b/views/js/test/tools/bandwidth/test.js
@@ -15,22 +15,22 @@
  *
  * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA ;
  */
-define( [  'context', 'taoClientDiagnostic/tools/bandwidth/tester' ], function(  context, bandwidthTester ) {
+define(['context', 'taoClientDiagnostic/tools/bandwidth/tester'], function(context, bandwidthTester) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.expect( 6 );
-        assert.ok( typeof bandwidthTester === 'function', 'The module exposes a function' );
-        assert.ok( typeof bandwidthTester() === 'object', 'bandwidthTester is a factory' );
-        assert.ok( typeof bandwidthTester().start === 'function', 'the test has a start method' );
-        assert.ok( typeof bandwidthTester().getSummary === 'function', 'the test has a getSummary method' );
-        assert.ok( typeof bandwidthTester().getFeedback === 'function', 'the test has a getFeedback method' );
-        assert.ok( typeof bandwidthTester().labels === 'object', 'the test has a labels objects' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.expect(6);
+        assert.ok(typeof bandwidthTester === 'function', 'The module exposes a function');
+        assert.ok(typeof bandwidthTester() === 'object', 'bandwidthTester is a factory');
+        assert.ok(typeof bandwidthTester().start === 'function', 'the test has a start method');
+        assert.ok(typeof bandwidthTester().getSummary === 'function', 'the test has a getSummary method');
+        assert.ok(typeof bandwidthTester().getFeedback === 'function', 'the test has a getFeedback method');
+        assert.ok(typeof bandwidthTester().labels === 'object', 'the test has a labels objects');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no level'
     }, {
         title: 'level 0',
@@ -44,9 +44,9 @@ define( [  'context', 'taoClientDiagnostic/tools/bandwidth/tester' ], function( 
     }, {
         title: 'level 3',
         level: 3
-    } ] )
-        .test( 'labels', function( data, assert ) {
-            var labels = bandwidthTester( { level: data.level } ).labels;
+    }])
+        .test('labels', function(data, assert) {
+            var labels = bandwidthTester({level: data.level}).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -56,86 +56,86 @@ define( [  'context', 'taoClientDiagnostic/tools/bandwidth/tester' ], function( 
                 'bandwidthAverage'
             ];
 
-            assert.expect( labelKeys.length + 1 );
+            assert.expect(labelKeys.length + 1);
 
-            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
-            labelKeys.forEach( function( key ) {
-                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
-            } );
-        } );
+            assert.equal(typeof labels, 'object', 'A set of labels is returned');
+            labelKeys.forEach(function(key) {
+                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
+            });
+        });
 
-    QUnit.test( 'getSummary', function( assert ) {
-        var tester = bandwidthTester( {} );
+    QUnit.test('getSummary', function(assert) {
+        var tester = bandwidthTester({});
         var results = {
             min: 30,
             max: 90,
             average: 60
         };
-        var summary = tester.getSummary( results );
+        var summary = tester.getSummary(results);
 
-        assert.expect( 10 );
+        assert.expect(10);
 
-        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
+        assert.equal(typeof summary, 'object', 'The method has returned the summary');
 
-        assert.equal( typeof summary.bandwidthMin, 'object', 'The summary contains entry for min bandwidth' );
-        assert.equal( typeof summary.bandwidthMin.message, 'string', 'The summary contains label for min bandwidth' );
-        assert.equal( summary.bandwidthMin.value, results.min + ' Mbps', 'The summary contains the expected value for min bandwidth' );
+        assert.equal(typeof summary.bandwidthMin, 'object', 'The summary contains entry for min bandwidth');
+        assert.equal(typeof summary.bandwidthMin.message, 'string', 'The summary contains label for min bandwidth');
+        assert.equal(summary.bandwidthMin.value, results.min + ' Mbps', 'The summary contains the expected value for min bandwidth');
 
-        assert.equal( typeof summary.bandwidthMax, 'object', 'The summary contains entry for max bandwidth' );
-        assert.equal( typeof summary.bandwidthMax.message, 'string', 'The summary contains label for max bandwidth' );
-        assert.equal( summary.bandwidthMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth' );
+        assert.equal(typeof summary.bandwidthMax, 'object', 'The summary contains entry for max bandwidth');
+        assert.equal(typeof summary.bandwidthMax.message, 'string', 'The summary contains label for max bandwidth');
+        assert.equal(summary.bandwidthMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth');
 
-        assert.equal( typeof summary.bandwidthAverage, 'object', 'The summary contains entry for average bandwidth' );
-        assert.equal( typeof summary.bandwidthAverage.message, 'string', 'The summary contains label for average bandwidth' );
-        assert.equal( summary.bandwidthAverage.value, results.average + ' Mbps', 'The summary contains the expected value for average bandwidth' );
-    } );
+        assert.equal(typeof summary.bandwidthAverage, 'object', 'The summary contains entry for average bandwidth');
+        assert.equal(typeof summary.bandwidthAverage.message, 'string', 'The summary contains label for average bandwidth');
+        assert.equal(summary.bandwidthAverage.value, results.average + ' Mbps', 'The summary contains the expected value for average bandwidth');
+    });
 
-    QUnit.test( 'getFeedback', function( assert ) {
-        var tester = bandwidthTester( {} );
-        var result = { max: 100, min: 10, average: 55 };
-        var status = tester.getFeedback( result );
+    QUnit.test('getFeedback', function(assert) {
+        var tester = bandwidthTester({});
+        var result = {max: 100, min: 10, average: 55};
+        var status = tester.getFeedback(result);
 
-        assert.expect( 6 );
+        assert.expect(6);
 
-        assert.equal( typeof status, 'object', 'The method has returned the status' );
-        assert.equal( status.id, 'bandwidth', 'The status contains the tester id' );
-        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
-        assert.equal( typeof status.title, 'string', 'The status contains a title' );
-        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
-        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
-    } );
+        assert.equal(typeof status, 'object', 'The method has returned the status');
+        assert.equal(status.id, 'bandwidth', 'The status contains the tester id');
+        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
+        assert.equal(typeof status.title, 'string', 'The status contains a title');
+        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
+        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
+    });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
-    QUnit.test( 'The tester runs', function( assert ) {
+    QUnit.test('The tester runs', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 13 );
+        assert.expect(13);
 
         // Override root_url to be able to download the files during unit tests
         context.root_url = '../../';
 
-        bandwidthTester( {} ).start( function( status, details, results ) {
+        bandwidthTester({}).start(function(status, details, results) {
 
             var toString = {}.toString;
             var speed = results.average;
 
-            assert.ok( typeof status === 'object', 'The status is a object' );
-            assert.ok( typeof details === 'object', 'The details is a object' );
-            assert.ok( typeof results === 'object', 'The results is a object' );
-            assert.ok( speed > 0, 'The result is a positive number' );
-            assert.ok( typeof results === 'object', 'The details are provided inside an object' );
-            assert.ok( typeof results.min === 'number', 'The minimum speed is provided inside the details' );
-            assert.ok( typeof results.max === 'number', 'The maximum speed is provided inside the details' );
-            assert.ok( typeof results.average === 'number', 'The average speed is provided inside the details' );
-            assert.ok( typeof results.variance === 'number', 'The speed variance is provided inside the details' );
-            assert.ok( typeof results.duration === 'number', 'The total duration of the test is provided inside the details' );
-            assert.ok( typeof results.size === 'number', 'The total size of the test is provided inside the details' );
-            assert.equal( speed, results.average, 'The speed provided inside the details must be equal to provided speed' );
-            assert.ok(toString.call( results.values ) === '[object Array]', 'The detailed measures are provided inside the details' );
+            assert.ok(typeof status === 'object', 'The status is a object');
+            assert.ok(typeof details === 'object', 'The details is a object');
+            assert.ok(typeof results === 'object', 'The results is a object');
+            assert.ok(speed > 0, 'The result is a positive number');
+            assert.ok(typeof results === 'object', 'The details are provided inside an object');
+            assert.ok(typeof results.min === 'number', 'The minimum speed is provided inside the details');
+            assert.ok(typeof results.max === 'number', 'The maximum speed is provided inside the details');
+            assert.ok(typeof results.average === 'number', 'The average speed is provided inside the details');
+            assert.ok(typeof results.variance === 'number', 'The speed variance is provided inside the details');
+            assert.ok(typeof results.duration === 'number', 'The total duration of the test is provided inside the details');
+            assert.ok(typeof results.size === 'number', 'The total size of the test is provided inside the details');
+            assert.equal(speed, results.average, 'The speed provided inside the details must be equal to provided speed');
+            assert.ok(toString.call(results.values) === '[object Array]', 'The detailed measures are provided inside the details');
 
             ready();
-        } );
-    } );
+        });
+    });
 
-} );
+});

--- a/views/js/test/tools/fingerprint/test.html
+++ b/views/js/test/tools/fingerprint/test.html
@@ -5,14 +5,15 @@
         <title>Test - Fingerprint Tester</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/fingerprint/tester"></script>
         <script  type="text/javascript">
 
             //don't start the test now
             QUnit.config.autostart = false;
+            QUnit.config.notrycatch = true;
 
             //load the config
             require(['/tao/ClientConfig/config'], function(){

--- a/views/js/test/tools/fingerprint/test.js
+++ b/views/js/test/tools/fingerprint/test.js
@@ -15,33 +15,32 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+
     'core/store',
     'taoClientDiagnostic/tools/fingerprint/tester',
     'taoClientDiagnostic/lib/fingerprint/fingerprint2'
-], function (storeMock, fingerprintTester, fingerprintMock) {
+], function(  storeMock, fingerprintTester, fingerprintMock ) {
     'use strict';
 
     var fingerprint = 'foo123bar456';
-    var components = [{
+    var components = [ {
         foo: 'bar'
-    }];
+    } ];
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.expect( 6 );
+        assert.ok( typeof fingerprintTester === 'function', 'The module exposes a function' );
+        assert.ok( typeof fingerprintTester() === 'object', 'fingerprintTester is a factory' );
+        assert.ok( typeof fingerprintTester().start === 'function', 'the test has a start method' );
+        assert.ok( typeof fingerprintTester().getSummary === 'function', 'the test has a getSummary method' );
+        assert.ok( typeof fingerprintTester().getFeedback === 'function', 'the test has a getFeedback method' );
+        assert.ok( typeof fingerprintTester().labels === 'object', 'the test has a labels objects' );
+    } );
 
-    QUnit.test('The tester has the right form', function (assert) {
-        QUnit.expect(6);
-        assert.ok(typeof fingerprintTester === 'function', 'The module exposes a function');
-        assert.ok(typeof fingerprintTester() === 'object', 'fingerprintTester is a factory');
-        assert.ok(typeof fingerprintTester().start === 'function', 'the test has a start method');
-        assert.ok(typeof fingerprintTester().getSummary === 'function', 'the test has a getSummary method');
-        assert.ok(typeof fingerprintTester().getFeedback === 'function', 'the test has a getFeedback method');
-        assert.ok(typeof fingerprintTester().labels === 'object', 'the test has a labels objects');
-    });
-
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no level'
     }, {
         title: 'level 0',
@@ -55,9 +54,9 @@ define([
     }, {
         title: 'level 3',
         level: 3
-    }])
-        .test('labels', function (data, assert) {
-            var labels = fingerprintTester({level: data.level}).labels;
+    } ] )
+        .test( 'labels', function( data, assert ) {
+            var labels = fingerprintTester( { level: data.level } ).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -68,24 +67,23 @@ define([
                 'fingerprintErrors'
             ];
 
-            QUnit.expect(labelKeys.length + 1);
+            assert.expect( labelKeys.length + 1 );
 
-            assert.equal(typeof labels, 'object', 'A set of labels is returned');
-            labelKeys.forEach(function (key) {
-                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
-            });
-        });
+            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
+            labelKeys.forEach( function( key ) {
+                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
+            } );
+        } );
 
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no errors',
         errors: false,
         results: {
             value: fingerprint,
             uuid: 1234,
-            details: [{
+            details: [ {
                 foo: 'bar'
-            }]
+            } ]
         }
     }, {
         title: 'with errors',
@@ -93,43 +91,42 @@ define([
         results: {
             value: fingerprint,
             uuid: 1234,
-            details: [{
+            details: [ {
                 foo: 'bar'
             }, {
                 type: 'error'
-            }],
+            } ],
             errors: 1
         }
-    }])
-        .test('getSummary', function (data, assert) {
-            var tester = fingerprintTester({});
-            var summary = tester.getSummary(data.results);
+    } ] )
+        .test( 'getSummary', function( data, assert ) {
+            var tester = fingerprintTester( {} );
+            var summary = tester.getSummary( data.results );
 
-            QUnit.expect(10 + (data.errors ? 3 : 0));
+            assert.expect( 10 + ( data.errors ? 3 : 0 ) );
 
-            assert.equal(typeof summary, 'object', 'The method has returned the summary');
+            assert.equal( typeof summary, 'object', 'The method has returned the summary' );
 
-            assert.equal(typeof summary.fingerprintValue, 'object', 'The summary contains entry for fingerprint');
-            assert.equal(typeof summary.fingerprintValue.message, 'string', 'The summary contains label for fingerprint');
-            assert.equal(summary.fingerprintValue.value, data.results.value, 'The summary contains the expected value for fingerprint');
+            assert.equal( typeof summary.fingerprintValue, 'object', 'The summary contains entry for fingerprint' );
+            assert.equal( typeof summary.fingerprintValue.message, 'string', 'The summary contains label for fingerprint' );
+            assert.equal( summary.fingerprintValue.value, data.results.value, 'The summary contains the expected value for fingerprint' );
 
-            assert.equal(typeof summary.fingerprintDetails, 'object', 'The summary contains entry for fingerprint sources');
-            assert.equal(typeof summary.fingerprintDetails.message, 'string', 'The summary contains label for fingerprint sources');
-            assert.equal(typeof summary.fingerprintDetails.value, 'string', 'The summary contains the expected value for fingerprint sources');
+            assert.equal( typeof summary.fingerprintDetails, 'object', 'The summary contains entry for fingerprint sources' );
+            assert.equal( typeof summary.fingerprintDetails.message, 'string', 'The summary contains label for fingerprint sources' );
+            assert.equal( typeof summary.fingerprintDetails.value, 'string', 'The summary contains the expected value for fingerprint sources' );
 
-            assert.equal(typeof summary.fingerprintChanged, 'object', 'The summary contains entry for fingerprint change');
-            assert.equal(typeof summary.fingerprintChanged.message, 'string', 'The summary contains label for fingerprint change');
-            assert.equal(typeof summary.fingerprintChanged.value, 'string', 'The summary contains the expected value for fingerprint change');
+            assert.equal( typeof summary.fingerprintChanged, 'object', 'The summary contains entry for fingerprint change' );
+            assert.equal( typeof summary.fingerprintChanged.message, 'string', 'The summary contains label for fingerprint change' );
+            assert.equal( typeof summary.fingerprintChanged.value, 'string', 'The summary contains the expected value for fingerprint change' );
 
-            if (data.errors) {
-                assert.equal(typeof summary.fingerprintErrors, 'object', 'The summary contains entry for fingerprint errors');
-                assert.equal(typeof summary.fingerprintErrors.message, 'string', 'The summary contains label for fingerprint errors');
-                assert.equal(summary.fingerprintErrors.value, data.results.errors, 'The summary contains the expected value for fingerprint errors');
+            if ( data.errors ) {
+                assert.equal( typeof summary.fingerprintErrors, 'object', 'The summary contains entry for fingerprint errors' );
+                assert.equal( typeof summary.fingerprintErrors.message, 'string', 'The summary contains label for fingerprint errors' );
+                assert.equal( summary.fingerprintErrors.value, data.results.errors, 'The summary contains the expected value for fingerprint errors' );
             }
-        });
+        } );
 
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'error no results',
         percentage: 0,
         type: 'error',
@@ -149,9 +146,9 @@ define([
             value: 'error',
             uuid: 1234,
             changed: false,
-            details: [{
+            details: [ {
                 foo: 'bar'
-            }]
+            } ]
         }
     }, {
         title: 'warning storage',
@@ -161,9 +158,9 @@ define([
             value: fingerprint,
             uuid: 'error',
             changed: false,
-            details: [{
+            details: [ {
                 foo: 'bar'
-            }]
+            } ]
         }
     }, {
         title: 'success but updated',
@@ -173,9 +170,9 @@ define([
             value: fingerprint,
             uuid: 1234,
             changed: true,
-            details: [{
+            details: [ {
                 foo: 'bar'
-            }]
+            } ]
         }
     }, {
         title: 'success',
@@ -185,132 +182,138 @@ define([
             value: fingerprint,
             uuid: 1234,
             changed: false,
-            details: [{
+            details: [ {
                 foo: 'bar'
-            }]
+            } ]
         }
-    }])
-        .test('getFeedback', function (data, assert) {
-            var tester = fingerprintTester({});
-            var status = tester.getFeedback(data.results);
+    } ] )
+        .test( 'getFeedback', function( data, assert ) {
+            var tester = fingerprintTester( {} );
+            var status = tester.getFeedback( data.results );
 
-            QUnit.expect(6);
+            assert.expect( 6 );
 
-            assert.equal(typeof status, 'object', 'The method has returned the status');
-            assert.equal(status.id, 'fingerprint', 'The status contains the tester id');
-            assert.equal(status.percentage, data.percentage, 'The status contains the expected percentage');
-            assert.equal(typeof status.title, 'string', 'The status contains a title');
-            assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
-            assert.equal(status.feedback.type, data.type, 'The status contains the expected feedback type');
-        });
+            assert.equal( typeof status, 'object', 'The method has returned the status' );
+            assert.equal( status.id, 'fingerprint', 'The status contains the tester id' );
+            assert.equal( status.percentage, data.percentage, 'The status contains the expected percentage' );
+            assert.equal( typeof status.title, 'string', 'The status contains a title' );
+            assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
+            assert.equal( status.feedback.type, data.type, 'The status contains the expected feedback type' );
+        } );
+
+    QUnit.module( 'Test');
 
 
-    QUnit.module('Test');
 
-    // cleans up the storage between each test
-    QUnit.testStart(function () {
-        storeMock('client-diagnostic').then(function (storage) {
+    QUnit.test( 'The tester runs', function( assert ) {
+        var ready = assert.async();
+
+        assert.expect( 6 );
+
+        fingerprintMock.fails = false;
+        fingerprintMock.result = fingerprint;
+        fingerprintMock.components = components;
+        storeMock.setConfig( 'client-diagnostic', {} );
+        storeMock( 'client-diagnostic' ).then( function( storage ) {
             storage.clear();
-        });
-    });
 
-    QUnit.asyncTest('The tester runs', function (assert) {
+            fingerprintTester( {} ).start( function( status, details, results ) {
 
-        QUnit.expect(6);
+                assert.equal( typeof status, 'object', 'The status is a object' );
+                assert.equal( typeof details, 'object', 'The details is a object' );
+                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
+                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
+                assert.equal( results.details, components, 'The fingerprint details are provided inside the results' );
+                assert.equal( typeof results.errors, 'undefined', 'No errors should be found' );
 
-        fingerprintMock.fails = false;
-        fingerprintMock.result = fingerprint;
-        fingerprintMock.components = components;
-        storeMock.setConfig('client-diagnostic', {});
+                ready();
+            } );
+        } );
 
-        fingerprintTester({}).start(function (status, details, results) {
+    } );
 
-            assert.equal(typeof status, 'object', 'The status is a object');
-            assert.equal(typeof details, 'object', 'The details is a object');
-            assert.equal(typeof results, 'object', 'The details are provided inside an object');
-            assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
-            assert.equal(results.details, components, 'The fingerprint details are provided inside the results');
-            assert.equal(typeof results.errors, 'undefined', 'No errors should be found');
+    QUnit.test( 'The tester runs, even if storage is not available', function( assert ) {
+        var ready = assert.async();
 
-            QUnit.start();
-        });
-
-    });
-
-    QUnit.asyncTest('The tester runs, even if storage is not available', function (assert) {
-
-        QUnit.expect(7);
+        assert.expect( 7 );
 
         fingerprintMock.fails = false;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig('client-diagnostic', {
-            failedStore: true
-        });
 
-        fingerprintTester({}).start(function (status, details, results) {
+        storeMock( 'client-diagnostic' ).then( function( storage ) {
+            storage.clear();
+            storeMock.setConfig( 'client-diagnostic', {
+                failedStore: true
+            } );
+            fingerprintTester( {} ).start( function( status, details, results ) {
 
-            assert.equal(typeof status, 'object', 'The status is a object');
-            assert.equal(typeof details, 'object', 'The details is a object');
-            assert.equal(typeof results, 'object', 'The details are provided inside an object');
-            assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
-            assert.deepEqual(results.details.slice(0, -1), components, 'The fingerprint details are provided inside the results');
-            assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
-            assert.equal(results.errors, 1, 'An error should be found');
+                assert.equal( typeof status, 'object', 'The status is a object' );
+                assert.equal( typeof details, 'object', 'The details is a object' );
+                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
+                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
+                assert.deepEqual( results.details.slice( 0, -1 ), components, 'The fingerprint details are provided inside the results' );
+                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
+                assert.equal( results.errors, 1, 'An error should be found' );
 
-            QUnit.start();
-        });
+                ready();
+            } );
+        } );
+    } );
 
-    });
+    QUnit.test( 'The tester runs, even if storage is not writable', function( assert ) {
+        var ready = assert.async();
 
-    QUnit.asyncTest('The tester runs, even if storage is not writable', function (assert) {
-
-        QUnit.expect(7);
+        assert.expect( 7 );
 
         fingerprintMock.fails = false;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig('client-diagnostic', {
+        storeMock.setConfig( 'client-diagnostic', {
             failedSet: true
-        });
+        } );
+        storeMock( 'client-diagnostic' ).then( function( storage ) {
+            storage.clear();
+            fingerprintTester( {} ).start( function( status, details, results ) {
 
-        fingerprintTester({}).start(function (status, details, results) {
+                assert.equal( typeof status, 'object', 'The status is a object' );
+                assert.equal( typeof details, 'object', 'The details is a object' );
+                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
+                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
+                assert.deepEqual( results.details.slice( 0, -1 ), components, 'The fingerprint details are provided inside the results' );
+                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
+                assert.equal( results.errors, 1, 'An error should be found' );
 
-            assert.equal(typeof status, 'object', 'The status is a object');
-            assert.equal(typeof details, 'object', 'The details is a object');
-            assert.equal(typeof results, 'object', 'The details are provided inside an object');
-            assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
-            assert.deepEqual(results.details.slice(0, -1), components, 'The fingerprint details are provided inside the results');
-            assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
-            assert.equal(results.errors, 1, 'An error should be found');
+                ready();
+            } );
+        } );
 
-            QUnit.start();
-        });
+    } );
 
-    });
+    QUnit.test( 'The tester runs, even if an error occurs', function( assert ) {
+        var ready = assert.async();
 
-    QUnit.asyncTest('The tester runs, even if an error occurs', function (assert) {
-
-        QUnit.expect(7);
+        assert.expect( 7 );
 
         fingerprintMock.fails = true;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig('client-diagnostic', {});
+        storeMock.setConfig( 'client-diagnostic', {} );
+        storeMock( 'client-diagnostic' ).then( function( storage ) {
+            storage.clear();
+            fingerprintTester( {} ).start( function( status, details, results ) {
 
-        fingerprintTester({}).start(function (status, details, results) {
+                assert.equal( typeof status, 'object', 'The status is a object' );
+                assert.equal( typeof details, 'object', 'The details is a object' );
+                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
+                assert.equal( typeof results.value, 'undefined', 'The fingerprint is not provided inside the results' );
+                assert.equal( results.details.length, 1, 'The fingerprint details are provided inside the results' );
+                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
+                assert.equal( results.errors, 1, 'An error should be found' );
 
-            assert.equal(typeof status, 'object', 'The status is a object');
-            assert.equal(typeof details, 'object', 'The details is a object');
-            assert.equal(typeof results, 'object', 'The details are provided inside an object');
-            assert.equal(typeof results.value, 'undefined', 'The fingerprint is not provided inside the results');
-            assert.equal(results.details.length, 1, 'The fingerprint details are provided inside the results');
-            assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
-            assert.equal(results.errors, 1, 'An error should be found');
+                ready();
+            } );
+        } );
+    } );
 
-            QUnit.start();
-        });
-
-    });
-
-});
+} );

--- a/views/js/test/tools/fingerprint/test.js
+++ b/views/js/test/tools/fingerprint/test.js
@@ -15,32 +15,32 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
+define([
 
     'core/store',
     'taoClientDiagnostic/tools/fingerprint/tester',
     'taoClientDiagnostic/lib/fingerprint/fingerprint2'
-], function(  storeMock, fingerprintTester, fingerprintMock ) {
+], function(storeMock, fingerprintTester, fingerprintMock) {
     'use strict';
 
     var fingerprint = 'foo123bar456';
-    var components = [ {
+    var components = [{
         foo: 'bar'
-    } ];
+    }];
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.expect( 6 );
-        assert.ok( typeof fingerprintTester === 'function', 'The module exposes a function' );
-        assert.ok( typeof fingerprintTester() === 'object', 'fingerprintTester is a factory' );
-        assert.ok( typeof fingerprintTester().start === 'function', 'the test has a start method' );
-        assert.ok( typeof fingerprintTester().getSummary === 'function', 'the test has a getSummary method' );
-        assert.ok( typeof fingerprintTester().getFeedback === 'function', 'the test has a getFeedback method' );
-        assert.ok( typeof fingerprintTester().labels === 'object', 'the test has a labels objects' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.expect(6);
+        assert.ok(typeof fingerprintTester === 'function', 'The module exposes a function');
+        assert.ok(typeof fingerprintTester() === 'object', 'fingerprintTester is a factory');
+        assert.ok(typeof fingerprintTester().start === 'function', 'the test has a start method');
+        assert.ok(typeof fingerprintTester().getSummary === 'function', 'the test has a getSummary method');
+        assert.ok(typeof fingerprintTester().getFeedback === 'function', 'the test has a getFeedback method');
+        assert.ok(typeof fingerprintTester().labels === 'object', 'the test has a labels objects');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no level'
     }, {
         title: 'level 0',
@@ -54,9 +54,9 @@ define( [
     }, {
         title: 'level 3',
         level: 3
-    } ] )
-        .test( 'labels', function( data, assert ) {
-            var labels = fingerprintTester( { level: data.level } ).labels;
+    }])
+        .test('labels', function(data, assert) {
+            var labels = fingerprintTester({level: data.level}).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -67,23 +67,23 @@ define( [
                 'fingerprintErrors'
             ];
 
-            assert.expect( labelKeys.length + 1 );
+            assert.expect(labelKeys.length + 1);
 
-            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
-            labelKeys.forEach( function( key ) {
-                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
-            } );
-        } );
+            assert.equal(typeof labels, 'object', 'A set of labels is returned');
+            labelKeys.forEach(function(key) {
+                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
+            });
+        });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no errors',
         errors: false,
         results: {
             value: fingerprint,
             uuid: 1234,
-            details: [ {
+            details: [{
                 foo: 'bar'
-            } ]
+            }]
         }
     }, {
         title: 'with errors',
@@ -91,42 +91,42 @@ define( [
         results: {
             value: fingerprint,
             uuid: 1234,
-            details: [ {
+            details: [{
                 foo: 'bar'
             }, {
                 type: 'error'
-            } ],
+            }],
             errors: 1
         }
-    } ] )
-        .test( 'getSummary', function( data, assert ) {
-            var tester = fingerprintTester( {} );
-            var summary = tester.getSummary( data.results );
+    }])
+        .test('getSummary', function(data, assert) {
+            var tester = fingerprintTester({});
+            var summary = tester.getSummary(data.results);
 
-            assert.expect( 10 + ( data.errors ? 3 : 0 ) );
+            assert.expect(10 + (data.errors ? 3 : 0));
 
-            assert.equal( typeof summary, 'object', 'The method has returned the summary' );
+            assert.equal(typeof summary, 'object', 'The method has returned the summary');
 
-            assert.equal( typeof summary.fingerprintValue, 'object', 'The summary contains entry for fingerprint' );
-            assert.equal( typeof summary.fingerprintValue.message, 'string', 'The summary contains label for fingerprint' );
-            assert.equal( summary.fingerprintValue.value, data.results.value, 'The summary contains the expected value for fingerprint' );
+            assert.equal(typeof summary.fingerprintValue, 'object', 'The summary contains entry for fingerprint');
+            assert.equal(typeof summary.fingerprintValue.message, 'string', 'The summary contains label for fingerprint');
+            assert.equal(summary.fingerprintValue.value, data.results.value, 'The summary contains the expected value for fingerprint');
 
-            assert.equal( typeof summary.fingerprintDetails, 'object', 'The summary contains entry for fingerprint sources' );
-            assert.equal( typeof summary.fingerprintDetails.message, 'string', 'The summary contains label for fingerprint sources' );
-            assert.equal( typeof summary.fingerprintDetails.value, 'string', 'The summary contains the expected value for fingerprint sources' );
+            assert.equal(typeof summary.fingerprintDetails, 'object', 'The summary contains entry for fingerprint sources');
+            assert.equal(typeof summary.fingerprintDetails.message, 'string', 'The summary contains label for fingerprint sources');
+            assert.equal(typeof summary.fingerprintDetails.value, 'string', 'The summary contains the expected value for fingerprint sources');
 
-            assert.equal( typeof summary.fingerprintChanged, 'object', 'The summary contains entry for fingerprint change' );
-            assert.equal( typeof summary.fingerprintChanged.message, 'string', 'The summary contains label for fingerprint change' );
-            assert.equal( typeof summary.fingerprintChanged.value, 'string', 'The summary contains the expected value for fingerprint change' );
+            assert.equal(typeof summary.fingerprintChanged, 'object', 'The summary contains entry for fingerprint change');
+            assert.equal(typeof summary.fingerprintChanged.message, 'string', 'The summary contains label for fingerprint change');
+            assert.equal(typeof summary.fingerprintChanged.value, 'string', 'The summary contains the expected value for fingerprint change');
 
-            if ( data.errors ) {
-                assert.equal( typeof summary.fingerprintErrors, 'object', 'The summary contains entry for fingerprint errors' );
-                assert.equal( typeof summary.fingerprintErrors.message, 'string', 'The summary contains label for fingerprint errors' );
-                assert.equal( summary.fingerprintErrors.value, data.results.errors, 'The summary contains the expected value for fingerprint errors' );
+            if (data.errors) {
+                assert.equal(typeof summary.fingerprintErrors, 'object', 'The summary contains entry for fingerprint errors');
+                assert.equal(typeof summary.fingerprintErrors.message, 'string', 'The summary contains label for fingerprint errors');
+                assert.equal(summary.fingerprintErrors.value, data.results.errors, 'The summary contains the expected value for fingerprint errors');
             }
-        } );
+        });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'error no results',
         percentage: 0,
         type: 'error',
@@ -146,9 +146,9 @@ define( [
             value: 'error',
             uuid: 1234,
             changed: false,
-            details: [ {
+            details: [{
                 foo: 'bar'
-            } ]
+            }]
         }
     }, {
         title: 'warning storage',
@@ -158,9 +158,9 @@ define( [
             value: fingerprint,
             uuid: 'error',
             changed: false,
-            details: [ {
+            details: [{
                 foo: 'bar'
-            } ]
+            }]
         }
     }, {
         title: 'success but updated',
@@ -170,9 +170,9 @@ define( [
             value: fingerprint,
             uuid: 1234,
             changed: true,
-            details: [ {
+            details: [{
                 foo: 'bar'
-            } ]
+            }]
         }
     }, {
         title: 'success',
@@ -182,138 +182,138 @@ define( [
             value: fingerprint,
             uuid: 1234,
             changed: false,
-            details: [ {
+            details: [{
                 foo: 'bar'
-            } ]
+            }]
         }
-    } ] )
-        .test( 'getFeedback', function( data, assert ) {
-            var tester = fingerprintTester( {} );
-            var status = tester.getFeedback( data.results );
+    }])
+        .test('getFeedback', function(data, assert) {
+            var tester = fingerprintTester({});
+            var status = tester.getFeedback(data.results);
 
-            assert.expect( 6 );
+            assert.expect(6);
 
-            assert.equal( typeof status, 'object', 'The method has returned the status' );
-            assert.equal( status.id, 'fingerprint', 'The status contains the tester id' );
-            assert.equal( status.percentage, data.percentage, 'The status contains the expected percentage' );
-            assert.equal( typeof status.title, 'string', 'The status contains a title' );
-            assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
-            assert.equal( status.feedback.type, data.type, 'The status contains the expected feedback type' );
-        } );
+            assert.equal(typeof status, 'object', 'The method has returned the status');
+            assert.equal(status.id, 'fingerprint', 'The status contains the tester id');
+            assert.equal(status.percentage, data.percentage, 'The status contains the expected percentage');
+            assert.equal(typeof status.title, 'string', 'The status contains a title');
+            assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
+            assert.equal(status.feedback.type, data.type, 'The status contains the expected feedback type');
+        });
 
-    QUnit.module( 'Test');
+    QUnit.module('Test');
 
 
 
-    QUnit.test( 'The tester runs', function( assert ) {
+    QUnit.test('The tester runs', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 6 );
+        assert.expect(6);
 
         fingerprintMock.fails = false;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig( 'client-diagnostic', {} );
-        storeMock( 'client-diagnostic' ).then( function( storage ) {
+        storeMock.setConfig('client-diagnostic', {});
+        storeMock('client-diagnostic').then(function(storage) {
             storage.clear();
 
-            fingerprintTester( {} ).start( function( status, details, results ) {
+            fingerprintTester({}).start(function(status, details, results) {
 
-                assert.equal( typeof status, 'object', 'The status is a object' );
-                assert.equal( typeof details, 'object', 'The details is a object' );
-                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
-                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
-                assert.equal( results.details, components, 'The fingerprint details are provided inside the results' );
-                assert.equal( typeof results.errors, 'undefined', 'No errors should be found' );
+                assert.equal(typeof status, 'object', 'The status is a object');
+                assert.equal(typeof details, 'object', 'The details is a object');
+                assert.equal(typeof results, 'object', 'The details are provided inside an object');
+                assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
+                assert.equal(results.details, components, 'The fingerprint details are provided inside the results');
+                assert.equal(typeof results.errors, 'undefined', 'No errors should be found');
 
                 ready();
-            } );
-        } );
+            });
+        });
 
-    } );
+    });
 
-    QUnit.test( 'The tester runs, even if storage is not available', function( assert ) {
+    QUnit.test('The tester runs, even if storage is not available', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 7 );
+        assert.expect(7);
 
         fingerprintMock.fails = false;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
 
-        storeMock( 'client-diagnostic' ).then( function( storage ) {
+        storeMock('client-diagnostic').then(function(storage) {
             storage.clear();
-            storeMock.setConfig( 'client-diagnostic', {
+            storeMock.setConfig('client-diagnostic', {
                 failedStore: true
-            } );
-            fingerprintTester( {} ).start( function( status, details, results ) {
+            });
+            fingerprintTester({}).start(function(status, details, results) {
 
-                assert.equal( typeof status, 'object', 'The status is a object' );
-                assert.equal( typeof details, 'object', 'The details is a object' );
-                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
-                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
-                assert.deepEqual( results.details.slice( 0, -1 ), components, 'The fingerprint details are provided inside the results' );
-                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
-                assert.equal( results.errors, 1, 'An error should be found' );
+                assert.equal(typeof status, 'object', 'The status is a object');
+                assert.equal(typeof details, 'object', 'The details is a object');
+                assert.equal(typeof results, 'object', 'The details are provided inside an object');
+                assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
+                assert.deepEqual(results.details.slice(0, -1), components, 'The fingerprint details are provided inside the results');
+                assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
+                assert.equal(results.errors, 1, 'An error should be found');
 
                 ready();
-            } );
-        } );
-    } );
+            });
+        });
+    });
 
-    QUnit.test( 'The tester runs, even if storage is not writable', function( assert ) {
+    QUnit.test('The tester runs, even if storage is not writable', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 7 );
+        assert.expect(7);
 
         fingerprintMock.fails = false;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig( 'client-diagnostic', {
+        storeMock.setConfig('client-diagnostic', {
             failedSet: true
-        } );
-        storeMock( 'client-diagnostic' ).then( function( storage ) {
+        });
+        storeMock('client-diagnostic').then(function(storage) {
             storage.clear();
-            fingerprintTester( {} ).start( function( status, details, results ) {
+            fingerprintTester({}).start(function(status, details, results) {
 
-                assert.equal( typeof status, 'object', 'The status is a object' );
-                assert.equal( typeof details, 'object', 'The details is a object' );
-                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
-                assert.equal( results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results' );
-                assert.deepEqual( results.details.slice( 0, -1 ), components, 'The fingerprint details are provided inside the results' );
-                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
-                assert.equal( results.errors, 1, 'An error should be found' );
+                assert.equal(typeof status, 'object', 'The status is a object');
+                assert.equal(typeof details, 'object', 'The details is a object');
+                assert.equal(typeof results, 'object', 'The details are provided inside an object');
+                assert.equal(results.value, fingerprint.toUpperCase(), 'The fingerprint is provided inside the results');
+                assert.deepEqual(results.details.slice(0, -1), components, 'The fingerprint details are provided inside the results');
+                assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
+                assert.equal(results.errors, 1, 'An error should be found');
 
                 ready();
-            } );
-        } );
+            });
+        });
 
-    } );
+    });
 
-    QUnit.test( 'The tester runs, even if an error occurs', function( assert ) {
+    QUnit.test('The tester runs, even if an error occurs', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 7 );
+        assert.expect(7);
 
         fingerprintMock.fails = true;
         fingerprintMock.result = fingerprint;
         fingerprintMock.components = components;
-        storeMock.setConfig( 'client-diagnostic', {} );
-        storeMock( 'client-diagnostic' ).then( function( storage ) {
+        storeMock.setConfig('client-diagnostic', {});
+        storeMock('client-diagnostic').then(function(storage) {
             storage.clear();
-            fingerprintTester( {} ).start( function( status, details, results ) {
+            fingerprintTester({}).start(function(status, details, results) {
 
-                assert.equal( typeof status, 'object', 'The status is a object' );
-                assert.equal( typeof details, 'object', 'The details is a object' );
-                assert.equal( typeof results, 'object', 'The details are provided inside an object' );
-                assert.equal( typeof results.value, 'undefined', 'The fingerprint is not provided inside the results' );
-                assert.equal( results.details.length, 1, 'The fingerprint details are provided inside the results' );
-                assert.equal( results.details.pop().key, 'error', 'The fingerprint error is provided inside the results' );
-                assert.equal( results.errors, 1, 'An error should be found' );
+                assert.equal(typeof status, 'object', 'The status is a object');
+                assert.equal(typeof details, 'object', 'The details is a object');
+                assert.equal(typeof results, 'object', 'The details are provided inside an object');
+                assert.equal(typeof results.value, 'undefined', 'The fingerprint is not provided inside the results');
+                assert.equal(results.details.length, 1, 'The fingerprint details are provided inside the results');
+                assert.equal(results.details.pop().key, 'error', 'The fingerprint error is provided inside the results');
+                assert.equal(results.errors, 1, 'An error should be found');
 
                 ready();
-            } );
-        } );
-    } );
+            });
+        });
+    });
 
-} );
+});

--- a/views/js/test/tools/fixedDecimals/test.html
+++ b/views/js/test/tools/fixedDecimals/test.html
@@ -5,8 +5,8 @@
         <title>Test - Fixed decimals</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/fixedDecimals"></script>
         <script  type="text/javascript">
 

--- a/views/js/test/tools/fixedDecimals/test.js
+++ b/views/js/test/tools/fixedDecimals/test.js
@@ -15,37 +15,37 @@
  *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/fixedDecimals' ], function(  fixedDecimals ) {
+define(['taoClientDiagnostic/tools/fixedDecimals'], function(fixedDecimals) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.ok( typeof fixedDecimals === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.ok(typeof fixedDecimals === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
-    QUnit.test( 'Conversions', function( assert ) {
+    QUnit.test('Conversions', function(assert) {
 
-        assert.equal( fixedDecimals( 10, 2 ), 10, 'Fix decimals on an integer' );
-        assert.equal( fixedDecimals( 10.6, 2 ), 10.6, 'Fix decimals on an already fixed decimals' );
-        assert.equal( fixedDecimals( 10.66, 2 ), 10.66, 'Fix decimals on an already fixed decimals' );
-        assert.equal( fixedDecimals( 10.666666666666, 2 ), 10.67, 'Fix decimals on an irrational value' );
-        assert.equal( fixedDecimals( 10.666666666666, 3 ), 10.667, 'Fix decimals on an irrational value' );
-        assert.equal( fixedDecimals( 10.111111111111, 2 ), 10.11, 'Fix decimals on an irrational value' );
-        assert.equal( fixedDecimals( 10.111111111111, 3 ), 10.111, 'Fix decimals on an irrational value' );
+        assert.equal(fixedDecimals(10, 2), 10, 'Fix decimals on an integer');
+        assert.equal(fixedDecimals(10.6, 2), 10.6, 'Fix decimals on an already fixed decimals');
+        assert.equal(fixedDecimals(10.66, 2), 10.66, 'Fix decimals on an already fixed decimals');
+        assert.equal(fixedDecimals(10.666666666666, 2), 10.67, 'Fix decimals on an irrational value');
+        assert.equal(fixedDecimals(10.666666666666, 3), 10.667, 'Fix decimals on an irrational value');
+        assert.equal(fixedDecimals(10.111111111111, 2), 10.11, 'Fix decimals on an irrational value');
+        assert.equal(fixedDecimals(10.111111111111, 3), 10.111, 'Fix decimals on an irrational value');
 
-        assert.equal( fixedDecimals( 10 ), 10, 'Fix decimals on an integer with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.6 ), 10.6, 'Fix decimals on an already fixed decimals with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.66 ), 10.7, 'Fix decimals on an already fixed decimals with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.666666666666 ), 10.7, 'Fix decimals on an irrational value with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.666666666666 ), 10.7, 'Fix decimals on an irrational value with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.111111111111 ), 10.1, 'Fix decimals on an irrational value with the default number of decimals' );
-        assert.equal( fixedDecimals( 10.111111111111 ), 10.1, 'Fix decimals on an irrational value with the default number of decimals' );
+        assert.equal(fixedDecimals(10), 10, 'Fix decimals on an integer with the default number of decimals');
+        assert.equal(fixedDecimals(10.6), 10.6, 'Fix decimals on an already fixed decimals with the default number of decimals');
+        assert.equal(fixedDecimals(10.66), 10.7, 'Fix decimals on an already fixed decimals with the default number of decimals');
+        assert.equal(fixedDecimals(10.666666666666), 10.7, 'Fix decimals on an irrational value with the default number of decimals');
+        assert.equal(fixedDecimals(10.666666666666), 10.7, 'Fix decimals on an irrational value with the default number of decimals');
+        assert.equal(fixedDecimals(10.111111111111), 10.1, 'Fix decimals on an irrational value with the default number of decimals');
+        assert.equal(fixedDecimals(10.111111111111), 10.1, 'Fix decimals on an irrational value with the default number of decimals');
 
-        assert.equal( fixedDecimals( 'one' ), 0, 'Fix decimals on a string' );
+        assert.equal(fixedDecimals('one'), 0, 'Fix decimals on a string');
 
-    } );
+    });
 
-} );
+});

--- a/views/js/test/tools/fixedDecimals/test.js
+++ b/views/js/test/tools/fixedDecimals/test.js
@@ -15,38 +15,37 @@
  *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/fixedDecimals'], function(fixedDecimals){
+define( [  'taoClientDiagnostic/tools/fixedDecimals' ], function(  fixedDecimals ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function(assert){
-        assert.ok(typeof fixedDecimals === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.ok( typeof fixedDecimals === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'Test' );
 
-    QUnit.module('Test');
+    QUnit.test( 'Conversions', function( assert ) {
 
-    QUnit.test('Conversions', function(assert){
+        assert.equal( fixedDecimals( 10, 2 ), 10, 'Fix decimals on an integer' );
+        assert.equal( fixedDecimals( 10.6, 2 ), 10.6, 'Fix decimals on an already fixed decimals' );
+        assert.equal( fixedDecimals( 10.66, 2 ), 10.66, 'Fix decimals on an already fixed decimals' );
+        assert.equal( fixedDecimals( 10.666666666666, 2 ), 10.67, 'Fix decimals on an irrational value' );
+        assert.equal( fixedDecimals( 10.666666666666, 3 ), 10.667, 'Fix decimals on an irrational value' );
+        assert.equal( fixedDecimals( 10.111111111111, 2 ), 10.11, 'Fix decimals on an irrational value' );
+        assert.equal( fixedDecimals( 10.111111111111, 3 ), 10.111, 'Fix decimals on an irrational value' );
 
-        assert.equal(fixedDecimals(10, 2), 10, 'Fix decimals on an integer');
-        assert.equal(fixedDecimals(10.6, 2), 10.6, 'Fix decimals on an already fixed decimals');
-        assert.equal(fixedDecimals(10.66, 2), 10.66, 'Fix decimals on an already fixed decimals');
-        assert.equal(fixedDecimals(10.666666666666, 2), 10.67, 'Fix decimals on an irrational value');
-        assert.equal(fixedDecimals(10.666666666666, 3), 10.667, 'Fix decimals on an irrational value');
-        assert.equal(fixedDecimals(10.111111111111, 2), 10.11, 'Fix decimals on an irrational value');
-        assert.equal(fixedDecimals(10.111111111111, 3), 10.111, 'Fix decimals on an irrational value');
+        assert.equal( fixedDecimals( 10 ), 10, 'Fix decimals on an integer with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.6 ), 10.6, 'Fix decimals on an already fixed decimals with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.66 ), 10.7, 'Fix decimals on an already fixed decimals with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.666666666666 ), 10.7, 'Fix decimals on an irrational value with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.666666666666 ), 10.7, 'Fix decimals on an irrational value with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.111111111111 ), 10.1, 'Fix decimals on an irrational value with the default number of decimals' );
+        assert.equal( fixedDecimals( 10.111111111111 ), 10.1, 'Fix decimals on an irrational value with the default number of decimals' );
 
-        assert.equal(fixedDecimals(10), 10, 'Fix decimals on an integer with the default number of decimals');
-        assert.equal(fixedDecimals(10.6), 10.6, 'Fix decimals on an already fixed decimals with the default number of decimals');
-        assert.equal(fixedDecimals(10.66), 10.7, 'Fix decimals on an already fixed decimals with the default number of decimals');
-        assert.equal(fixedDecimals(10.666666666666), 10.7, 'Fix decimals on an irrational value with the default number of decimals');
-        assert.equal(fixedDecimals(10.666666666666), 10.7, 'Fix decimals on an irrational value with the default number of decimals');
-        assert.equal(fixedDecimals(10.111111111111), 10.1, 'Fix decimals on an irrational value with the default number of decimals');
-        assert.equal(fixedDecimals(10.111111111111), 10.1, 'Fix decimals on an irrational value with the default number of decimals');
+        assert.equal( fixedDecimals( 'one' ), 0, 'Fix decimals on a string' );
 
-        assert.equal(fixedDecimals("one"), 0, 'Fix decimals on a string');
+    } );
 
-    });
-
-});
+} );

--- a/views/js/test/tools/getConfig/test.html
+++ b/views/js/test/tools/getConfig/test.html
@@ -5,8 +5,8 @@
         <title>Test - Get Config</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/getConfig"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/getConfig/test.js
+++ b/views/js/test/tools/getConfig/test.js
@@ -15,20 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/getConfig'], function(getConfig){
+define( [  'taoClientDiagnostic/tools/getConfig' ], function(  getConfig ) {
     'use strict';
 
-    QUnit.module('Module');
+    QUnit.module( 'Module' );
 
-    QUnit.test('The helper has the right form', function(assert){
-        QUnit.expect(1);
-        assert.ok(typeof getConfig === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The helper has the right form', function( assert ) {
+        assert.expect( 1 );
+        assert.ok( typeof getConfig === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no config, no defaults',
         expected: {}
     }, {
@@ -81,10 +80,10 @@ define(['taoClientDiagnostic/tools/getConfig'], function(getConfig){
             foo: 'test',
             name: 'foo'
         }
-    }]).test('getConfig ', function(data, assert){
-        var config = getConfig(data.config, data.defaults);
-        QUnit.expect(1);
-        assert.deepEqual(config, data.expected, 'The helper has returned the expected data');
-    });
+    } ] ).test( 'getConfig ', function( data, assert ) {
+        var config = getConfig( data.config, data.defaults );
+        assert.expect( 1 );
+        assert.deepEqual( config, data.expected, 'The helper has returned the expected data' );
+    } );
 
-});
+} );

--- a/views/js/test/tools/getConfig/test.js
+++ b/views/js/test/tools/getConfig/test.js
@@ -15,19 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/getConfig' ], function(  getConfig ) {
+define(['taoClientDiagnostic/tools/getConfig'], function(getConfig) {
     'use strict';
 
-    QUnit.module( 'Module' );
+    QUnit.module('Module');
 
-    QUnit.test( 'The helper has the right form', function( assert ) {
-        assert.expect( 1 );
-        assert.ok( typeof getConfig === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The helper has the right form', function(assert) {
+        assert.expect(1);
+        assert.ok(typeof getConfig === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no config, no defaults',
         expected: {}
     }, {
@@ -80,10 +80,10 @@ define( [  'taoClientDiagnostic/tools/getConfig' ], function(  getConfig ) {
             foo: 'test',
             name: 'foo'
         }
-    } ] ).test( 'getConfig ', function( data, assert ) {
-        var config = getConfig( data.config, data.defaults );
-        assert.expect( 1 );
-        assert.deepEqual( config, data.expected, 'The helper has returned the expected data' );
-    } );
+    }]).test('getConfig ', function(data, assert) {
+        var config = getConfig(data.config, data.defaults);
+        assert.expect(1);
+        assert.deepEqual(config, data.expected, 'The helper has returned the expected data');
+    });
 
-} );
+});

--- a/views/js/test/tools/getLabels/test.html
+++ b/views/js/test/tools/getLabels/test.html
@@ -5,8 +5,8 @@
         <title>Test - Get Labels</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/getLabels"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/getLabels/test.js
+++ b/views/js/test/tools/getLabels/test.js
@@ -15,19 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
+define(['taoClientDiagnostic/tools/getLabels'], function(getLabels) {
     'use strict';
 
-    QUnit.module( 'Module' );
+    QUnit.module('Module');
 
-    QUnit.test( 'The helper has the right form', function( assert ) {
-        assert.expect( 1 );
-        assert.ok( typeof getLabels === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The helper has the right form', function(assert) {
+        assert.expect(1);
+        assert.ok(typeof getLabels === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no messages, no level',
         expected: {}
     }, {
@@ -58,10 +58,10 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 1 message, level 1',
         level: 1,
-        messages: [ {
+        messages: [{
             title: 'foo',
             status: 'bar'
-        } ],
+        }],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -69,10 +69,10 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 1 message, level 2',
         level: 2,
-        messages: [ {
+        messages: [{
             title: 'foo',
             status: 'bar'
-        } ],
+        }],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -80,10 +80,10 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 1 message, level 0',
         level: 0,
-        messages: [ {
+        messages: [{
             title: 'foo',
             status: 'bar'
-        } ],
+        }],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -91,13 +91,13 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 2 messages, level 0',
         level: 0,
-        messages: [ {
+        messages: [{
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        } ],
+        }],
         expected: {
             title: 'level1',
             status: 'foo bar 1'
@@ -105,13 +105,13 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 2 messages, level 1',
         level: 1,
-        messages: [ {
+        messages: [{
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        } ],
+        }],
         expected: {
             title: 'level1',
             status: 'foo bar 1'
@@ -119,13 +119,13 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 2 messages, level 2',
         level: 2,
-        messages: [ {
+        messages: [{
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        } ],
+        }],
         expected: {
             title: 'level2',
             status: 'foo bar 2'
@@ -133,21 +133,21 @@ define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     }, {
         title: 'list with 2 messages, level 3',
         level: 3,
-        messages: [ {
+        messages: [{
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        } ],
+        }],
         expected: {
             title: 'level2',
             status: 'foo bar 2'
         }
-    } ] ).test( 'getLabels ', function( data, assert ) {
-        var labels = getLabels( data.messages, data.level );
-        assert.expect( 1 );
-        assert.deepEqual( labels, data.expected, 'The helper has returned the expected data' );
-    } );
+    }]).test('getLabels ', function(data, assert) {
+        var labels = getLabels(data.messages, data.level);
+        assert.expect(1);
+        assert.deepEqual(labels, data.expected, 'The helper has returned the expected data');
+    });
 
-} );
+});

--- a/views/js/test/tools/getLabels/test.js
+++ b/views/js/test/tools/getLabels/test.js
@@ -15,20 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
+define( [  'taoClientDiagnostic/tools/getLabels' ], function(  getLabels ) {
     'use strict';
 
-    QUnit.module('Module');
+    QUnit.module( 'Module' );
 
-    QUnit.test('The helper has the right form', function(assert){
-        QUnit.expect(1);
-        assert.ok(typeof getLabels === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The helper has the right form', function( assert ) {
+        assert.expect( 1 );
+        assert.ok( typeof getLabels === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no messages, no level',
         expected: {}
     }, {
@@ -59,10 +58,10 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 1 message, level 1',
         level: 1,
-        messages: [{
+        messages: [ {
             title: 'foo',
             status: 'bar'
-        }],
+        } ],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -70,10 +69,10 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 1 message, level 2',
         level: 2,
-        messages: [{
+        messages: [ {
             title: 'foo',
             status: 'bar'
-        }],
+        } ],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -81,10 +80,10 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 1 message, level 0',
         level: 0,
-        messages: [{
+        messages: [ {
             title: 'foo',
             status: 'bar'
-        }],
+        } ],
         expected: {
             title: 'foo',
             status: 'bar'
@@ -92,13 +91,13 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 2 messages, level 0',
         level: 0,
-        messages: [{
+        messages: [ {
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        }],
+        } ],
         expected: {
             title: 'level1',
             status: 'foo bar 1'
@@ -106,13 +105,13 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 2 messages, level 1',
         level: 1,
-        messages: [{
+        messages: [ {
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        }],
+        } ],
         expected: {
             title: 'level1',
             status: 'foo bar 1'
@@ -120,13 +119,13 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 2 messages, level 2',
         level: 2,
-        messages: [{
+        messages: [ {
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        }],
+        } ],
         expected: {
             title: 'level2',
             status: 'foo bar 2'
@@ -134,21 +133,21 @@ define(['taoClientDiagnostic/tools/getLabels'], function(getLabels){
     }, {
         title: 'list with 2 messages, level 3',
         level: 3,
-        messages: [{
+        messages: [ {
             title: 'level1',
             status: 'foo bar 1'
         }, {
             title: 'level2',
             status: 'foo bar 2'
-        }],
+        } ],
         expected: {
             title: 'level2',
             status: 'foo bar 2'
         }
-    }]).test('getLabels ', function(data, assert){
-        var labels = getLabels(data.messages, data.level);
-        QUnit.expect(1);
-        assert.deepEqual(labels, data.expected, 'The helper has returned the expected data');
-    });
+    } ] ).test( 'getLabels ', function( data, assert ) {
+        var labels = getLabels( data.messages, data.level );
+        assert.expect( 1 );
+        assert.deepEqual( labels, data.expected, 'The helper has returned the expected data' );
+    } );
 
-});
+} );

--- a/views/js/test/tools/getPlatformInfo/test.html
+++ b/views/js/test/tools/getPlatformInfo/test.html
@@ -5,8 +5,8 @@
         <title>Test - Get Platform Info</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/getPlatformInfo"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/getPlatformInfo/test.js
+++ b/views/js/test/tools/getPlatformInfo/test.js
@@ -15,19 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
+define([
 
     'jquery',
     'context',
     'util/url',
     'taoClientDiagnostic/tools/getPlatformInfo'
-], function(  $, context, url, getPlatformInfo ) {
+], function($, context, url, getPlatformInfo) {
     'use strict';
 
     var ajaxBackup;
 
     // Hotfix the URL to bring consistency between test platforms (browser and CLI)
-    context[ 'root_url' ] = 'http://tao.lan';
+    context['root_url'] = 'http://tao.lan';
 
     /**
      * A simple AJAX mock factory that fakes a successful ajax call.
@@ -37,10 +37,10 @@ define( [
      * @param {Function} [validator] - An optional function called instead of the ajax method
      * @returns {Function}
      */
-    function ajaxMockSuccess( response, validator ) {
-        var deferred = $.Deferred().resolve( response );
+    function ajaxMockSuccess(response, validator) {
+        var deferred = $.Deferred().resolve(response);
         return function() {
-            validator && validator.apply( this, arguments );
+            validator && validator.apply(this, arguments);
             return deferred.promise();
         };
     }
@@ -53,32 +53,32 @@ define( [
      * @param {Function} [validator] - An optional function called instead of the ajax method
      * @returns {Function}
      */
-    function ajaxMockError( response, validator ) {
-        var deferred = $.Deferred().reject( response );
+    function ajaxMockError(response, validator) {
+        var deferred = $.Deferred().reject(response);
         return function() {
-            validator && validator.apply( this, arguments );
+            validator && validator.apply(this, arguments);
             return deferred.promise();
         };
     }
 
-    QUnit.module( 'Module' );
+    QUnit.module('Module');
 
-    QUnit.test( 'The helper has the right form', function( assert ) {
-        assert.expect( 1 );
-        assert.ok( typeof getPlatformInfo === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The helper has the right form', function(assert) {
+        assert.expect(1);
+        assert.ok(typeof getPlatformInfo === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
     // Backup/restore ajax method between each test
-    QUnit.testStart( function() {
+    QUnit.testStart(function() {
         ajaxBackup = $.ajax;
-    } );
-    QUnit.testDone( function() {
+    });
+    QUnit.testDone(function() {
         $.ajax = ajaxBackup;
-    } );
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'success',
         ajaxMock: ajaxMockSuccess,
         window: {
@@ -142,37 +142,37 @@ define( [
             w: 'undefined',
             h: 'undefined'
         }
-    } ] ).test( 'getPlatformInfo ', function( data, assert ) {
+    }]).test('getPlatformInfo ', function(data, assert) {
         var ready = assert.async();
-        $.ajax = data.ajaxMock( data.response, function( config ) {
-            var parsedUrl = url.parse( config.url );
+        $.ajax = data.ajaxMock(data.response, function(config) {
+            var parsedUrl = url.parse(config.url);
 
-            assert.equal( typeof parsedUrl.query.r, 'string', 'The helper has set a cache buster' );
+            assert.equal(typeof parsedUrl.query.r, 'string', 'The helper has set a cache buster');
             delete parsedUrl.query.r;
-            assert.equal( parsedUrl.path, data.urlPath, 'The helper has called the right service' );
-            assert.deepEqual( parsedUrl.query, data.urlParams, 'The helper has provided the expected params' );
-        } );
+            assert.equal(parsedUrl.path, data.urlPath, 'The helper has called the right service');
+            assert.deepEqual(parsedUrl.query, data.urlParams, 'The helper has provided the expected params');
+        });
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        getPlatformInfo( data.window, data.config )
-            .then( function( result ) {
-                if ( data.failed ) {
-                    assert.ok( false, 'The helper should fail!' );
+        getPlatformInfo(data.window, data.config)
+            .then(function(result) {
+                if (data.failed) {
+                    assert.ok(false, 'The helper should fail!');
                 } else {
-                    assert.deepEqual( result, data.response, 'The helper has returned the expected result' );
+                    assert.deepEqual(result, data.response, 'The helper has returned the expected result');
                 }
                 ready();
-            } )
-            .catch( function( err ) {
-                if ( data.failed ) {
-                    assert.deepEqual( err, data.response, 'The helper has provided the expected error' );
+            })
+            .catch(function(err) {
+                if (data.failed) {
+                    assert.deepEqual(err, data.response, 'The helper has provided the expected error');
                 } else {
-                    console.error( err );
-                    assert.ok( false, 'The helper should not fail!' );
+                    console.error(err);
+                    assert.ok(false, 'The helper should not fail!');
                 }
                 ready();
-            } );
-    } );
+            });
+    });
 
-} );
+});

--- a/views/js/test/tools/getPlatformInfo/test.js
+++ b/views/js/test/tools/getPlatformInfo/test.js
@@ -15,18 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+
     'jquery',
     'context',
     'util/url',
     'taoClientDiagnostic/tools/getPlatformInfo'
-], function ($, context, url, getPlatformInfo) {
+], function(  $, context, url, getPlatformInfo ) {
     'use strict';
 
     var ajaxBackup;
 
-    // hotfix the URL to bring consistency between test platforms (browser and CLI)
-    context['root_url'] = 'http://tao.lan';
+    // Hotfix the URL to bring consistency between test platforms (browser and CLI)
+    context[ 'root_url' ] = 'http://tao.lan';
 
     /**
      * A simple AJAX mock factory that fakes a successful ajax call.
@@ -36,14 +37,13 @@ define([
      * @param {Function} [validator] - An optional function called instead of the ajax method
      * @returns {Function}
      */
-    function ajaxMockSuccess(response, validator) {
-        var deferred = $.Deferred().resolve(response);
-        return function () {
-            validator && validator.apply(this, arguments);
+    function ajaxMockSuccess( response, validator ) {
+        var deferred = $.Deferred().resolve( response );
+        return function() {
+            validator && validator.apply( this, arguments );
             return deferred.promise();
         };
     }
-
 
     /**
      * A simple AJAX mock factory that fakes a failing ajax call.
@@ -53,39 +53,38 @@ define([
      * @param {Function} [validator] - An optional function called instead of the ajax method
      * @returns {Function}
      */
-    function ajaxMockError(response, validator) {
-        var deferred = $.Deferred().reject(response);
-        return function () {
-            validator && validator.apply(this, arguments);
+    function ajaxMockError( response, validator ) {
+        var deferred = $.Deferred().reject( response );
+        return function() {
+            validator && validator.apply( this, arguments );
             return deferred.promise();
         };
     }
 
-    QUnit.module('Module');
+    QUnit.module( 'Module' );
 
-    QUnit.test('The helper has the right form', function (assert) {
-        QUnit.expect(1);
-        assert.ok(typeof getPlatformInfo === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The helper has the right form', function( assert ) {
+        assert.expect( 1 );
+        assert.ok( typeof getPlatformInfo === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
-
-    // backup/restore ajax method between each test
-    QUnit.testStart(function () {
+    // Backup/restore ajax method between each test
+    QUnit.testStart( function() {
         ajaxBackup = $.ajax;
-    });
-    QUnit.testDone(function () {
+    } );
+    QUnit.testDone( function() {
         $.ajax = ajaxBackup;
-    });
+    } );
 
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'success',
         ajaxMock: ajaxMockSuccess,
         window: {
             document: {
                 documentElement: {},
-                createElement: function () {
+                createElement: function() {
                     return {};
                 }
             },
@@ -117,7 +116,7 @@ define([
         window: {
             document: {
                 documentElement: {},
-                createElement: function () {
+                createElement: function() {
                     return {};
                 }
             },
@@ -143,37 +142,37 @@ define([
             w: 'undefined',
             h: 'undefined'
         }
-    }]).asyncTest('getPlatformInfo ', function (data, assert) {
-        $.ajax = data.ajaxMock(data.response, function (config) {
-            var parsedUrl = url.parse(config.url);
+    } ] ).test( 'getPlatformInfo ', function( data, assert ) {
+        var ready = assert.async();
+        $.ajax = data.ajaxMock( data.response, function( config ) {
+            var parsedUrl = url.parse( config.url );
 
-            assert.equal(typeof parsedUrl.query.r, 'string', 'The helper has set a cache buster');
+            assert.equal( typeof parsedUrl.query.r, 'string', 'The helper has set a cache buster' );
             delete parsedUrl.query.r;
-            assert.equal(parsedUrl.path, data.urlPath, 'The helper has called the right service');
-            assert.deepEqual(parsedUrl.query, data.urlParams, 'The helper has provided the expected params');
-        });
+            assert.equal( parsedUrl.path, data.urlPath, 'The helper has called the right service' );
+            assert.deepEqual( parsedUrl.query, data.urlParams, 'The helper has provided the expected params' );
+        } );
 
-        QUnit.expect(4);
+        assert.expect( 4 );
 
-
-        getPlatformInfo(data.window, data.config)
-            .then(function (result) {
-                if (data.failed) {
-                    assert.ok(false, 'The helper should fail!');
+        getPlatformInfo( data.window, data.config )
+            .then( function( result ) {
+                if ( data.failed ) {
+                    assert.ok( false, 'The helper should fail!' );
                 } else {
-                    assert.deepEqual(result, data.response, 'The helper has returned the expected result');
+                    assert.deepEqual( result, data.response, 'The helper has returned the expected result' );
                 }
-                QUnit.start();
-            })
-            .catch(function (err) {
-                if (data.failed) {
-                    assert.deepEqual(err, data.response, 'The helper has provided the expected error');
+                ready();
+            } )
+            .catch( function( err ) {
+                if ( data.failed ) {
+                    assert.deepEqual( err, data.response, 'The helper has provided the expected error' );
                 } else {
-                    console.error(err);
-                    assert.ok(false, 'The helper should not fail!');
+                    console.error( err );
+                    assert.ok( false, 'The helper should not fail!' );
                 }
-                QUnit.start();
-            });
-    });
+                ready();
+            } );
+    } );
 
-});
+} );

--- a/views/js/test/tools/getStatus/test.html
+++ b/views/js/test/tools/getStatus/test.html
@@ -5,8 +5,8 @@
         <title>Test - Get Status</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/getStatus"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/getStatus/test.js
+++ b/views/js/test/tools/getStatus/test.js
@@ -15,19 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
+define(['taoClientDiagnostic/tools/getStatus'], function(getStatus) {
     'use strict';
 
-    QUnit.module( 'Module' );
+    QUnit.module('Module');
 
-    QUnit.test( 'The helper has the right form', function( assert ) {
-        assert.expect( 1 );
-        assert.ok( typeof getStatus === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The helper has the right form', function(assert) {
+        assert.expect(1);
+        assert.ok(typeof getStatus === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no percentage, no thresholds',
         expected: {
             percentage: 0,
@@ -100,13 +100,13 @@ define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
     }, {
         title: '20%, threshold 25%, 50%, 75%',
         percentage: 20,
-        thresholds: [ {
+        thresholds: [{
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        } ],
+        }],
         expected: {
             percentage: 20,
             globalPercentage: 20,
@@ -115,13 +115,13 @@ define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
     }, {
         title: '30%, threshold 25%, 50%, 75%',
         percentage: 30,
-        thresholds: [ {
+        thresholds: [{
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        } ],
+        }],
         expected: {
             percentage: 30,
             globalPercentage: 30,
@@ -133,13 +133,13 @@ define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
     }, {
         title: '60%, threshold 25%, 50%, 75%',
         percentage: 60,
-        thresholds: [ {
+        thresholds: [{
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        } ],
+        }],
         expected: {
             percentage: 60,
             globalPercentage: 60,
@@ -151,13 +151,13 @@ define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
     }, {
         title: '60%, threshold 25%, 50%, 75%',
         percentage: 80,
-        thresholds: [ {
+        thresholds: [{
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        } ],
+        }],
         expected: {
             percentage: 80,
             globalPercentage: 80,
@@ -194,10 +194,10 @@ define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
             globalPercentage: 10,
             quality: {}
         }
-    } ] ).test( 'getStatus ', function( data, assert ) {
-        var status = getStatus( data.percentage, data.thresholds, data.options );
-        assert.expect( 1 );
-        assert.deepEqual( status, data.expected, 'The helper has returned the expected data' );
-    } );
+    }]).test('getStatus ', function(data, assert) {
+        var status = getStatus(data.percentage, data.thresholds, data.options);
+        assert.expect(1);
+        assert.deepEqual(status, data.expected, 'The helper has returned the expected data');
+    });
 
-} );
+});

--- a/views/js/test/tools/getStatus/test.js
+++ b/views/js/test/tools/getStatus/test.js
@@ -15,20 +15,19 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
+define( [  'taoClientDiagnostic/tools/getStatus' ], function(  getStatus ) {
     'use strict';
 
-    QUnit.module('Module');
+    QUnit.module( 'Module' );
 
-    QUnit.test('The helper has the right form', function(assert){
-        QUnit.expect(1);
-        assert.ok(typeof getStatus === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The helper has the right form', function( assert ) {
+        assert.expect( 1 );
+        assert.ok( typeof getStatus === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no percentage, no thresholds',
         expected: {
             percentage: 0,
@@ -101,13 +100,13 @@ define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
     }, {
         title: '20%, threshold 25%, 50%, 75%',
         percentage: 20,
-        thresholds: [{
+        thresholds: [ {
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        }],
+        } ],
         expected: {
             percentage: 20,
             globalPercentage: 20,
@@ -116,13 +115,13 @@ define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
     }, {
         title: '30%, threshold 25%, 50%, 75%',
         percentage: 30,
-        thresholds: [{
+        thresholds: [ {
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        }],
+        } ],
         expected: {
             percentage: 30,
             globalPercentage: 30,
@@ -134,13 +133,13 @@ define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
     }, {
         title: '60%, threshold 25%, 50%, 75%',
         percentage: 60,
-        thresholds: [{
+        thresholds: [ {
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        }],
+        } ],
         expected: {
             percentage: 60,
             globalPercentage: 60,
@@ -152,13 +151,13 @@ define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
     }, {
         title: '60%, threshold 25%, 50%, 75%',
         percentage: 80,
-        thresholds: [{
+        thresholds: [ {
             threshold: 25
         }, {
             threshold: 50
         }, {
             threshold: 75
-        }],
+        } ],
         expected: {
             percentage: 80,
             globalPercentage: 80,
@@ -195,10 +194,10 @@ define(['taoClientDiagnostic/tools/getStatus'], function(getStatus){
             globalPercentage: 10,
             quality: {}
         }
-    }]).test('getStatus ', function(data, assert){
-        var status = getStatus(data.percentage, data.thresholds, data.options);
-        QUnit.expect(1);
-        assert.deepEqual(status, data.expected, 'The helper has returned the expected data');
-    });
+    } ] ).test( 'getStatus ', function( data, assert ) {
+        var status = getStatus( data.percentage, data.thresholds, data.options );
+        assert.expect( 1 );
+        assert.deepEqual( status, data.expected, 'The helper has returned the expected data' );
+    } );
 
-});
+} );

--- a/views/js/test/tools/message/test.html
+++ b/views/js/test/tools/message/test.html
@@ -5,8 +5,8 @@
         <title>Test - Message</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/message"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/message/test.js
+++ b/views/js/test/tools/message/test.js
@@ -15,23 +15,24 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+
     'jquery',
     'ui/feedback',
-    'taoClientDiagnostic/tools/message'], function ($, feedbackMock, message) {
+    'taoClientDiagnostic/tools/message'
+], function(  $, feedbackMock, message ) {
     'use strict';
 
-    QUnit.module('Module');
+    QUnit.module( 'Module' );
 
-    QUnit.test('The helper has the right form', function (assert) {
-        QUnit.expect(1);
-        assert.ok(typeof message === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The helper has the right form', function( assert ) {
+        assert.expect( 1 );
+        assert.ok( typeof message === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'API' );
 
-    QUnit.module('API');
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'message',
         data: 'message',
         text: 'This is a message'
@@ -41,29 +42,31 @@ define([
         text: 'This is an error'
     }, {
         title: 'nothing'
-    }]).asyncTest('message ', function (data, assert) {
-        var $container = $('#fixture');
-        var delay = setTimeout(function() {
-            assert.ok(!data.data, 'The feedback has not been displayed');
-            QUnit.start();
-        }, 250);
+    } ] ).test( 'message ', function( data, assert ) {
+        var ready = assert.async();
+        var $container = $( '#fixture' );
+        var delay = setTimeout( function() {
+            assert.ok( !data.data, 'The feedback has not been displayed' );
+            ready();
+        }, 250 );
+        assert.expect( 1 );
 
-        feedbackMock.callback = function(text) {
-            clearTimeout(delay);
-            if (data.data) {
-                assert.equal(text, data.text);
+
+        feedbackMock.callback = function( text ) {
+            clearTimeout( delay );
+            if ( data.data ) {
+                assert.equal( text, data.text );
             } else {
-                assert.ok(false, 'The feedback should not have been displayed');
+                assert.ok( false, 'The feedback should not have been displayed' );
             }
-            QUnit.start();
+            ready();
         };
 
-        QUnit.expect(1);
 
-        if (data.data) {
-            $container.data(data.data, data.text);
+        if ( data.data ) {
+            $container.data( data.data, data.text );
         }
-        message($container);
-    });
+        message( $container );
+    } );
 
-});
+} );

--- a/views/js/test/tools/message/test.js
+++ b/views/js/test/tools/message/test.js
@@ -15,24 +15,24 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
+define([
 
     'jquery',
     'ui/feedback',
     'taoClientDiagnostic/tools/message'
-], function(  $, feedbackMock, message ) {
+], function($, feedbackMock, message) {
     'use strict';
 
-    QUnit.module( 'Module' );
+    QUnit.module('Module');
 
-    QUnit.test( 'The helper has the right form', function( assert ) {
-        assert.expect( 1 );
-        assert.ok( typeof message === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The helper has the right form', function(assert) {
+        assert.expect(1);
+        assert.ok(typeof message === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'message',
         data: 'message',
         text: 'This is a message'
@@ -42,31 +42,31 @@ define( [
         text: 'This is an error'
     }, {
         title: 'nothing'
-    } ] ).test( 'message ', function( data, assert ) {
+    }]).test('message ', function(data, assert) {
         var ready = assert.async();
-        var $container = $( '#fixture' );
-        var delay = setTimeout( function() {
-            assert.ok( !data.data, 'The feedback has not been displayed' );
+        var $container = $('#fixture');
+        var delay = setTimeout(function() {
+            assert.ok(!data.data, 'The feedback has not been displayed');
             ready();
-        }, 250 );
-        assert.expect( 1 );
+        }, 250);
+        assert.expect(1);
 
 
-        feedbackMock.callback = function( text ) {
-            clearTimeout( delay );
-            if ( data.data ) {
-                assert.equal( text, data.text );
+        feedbackMock.callback = function(text) {
+            clearTimeout(delay);
+            if (data.data) {
+                assert.equal(text, data.text);
             } else {
-                assert.ok( false, 'The feedback should not have been displayed' );
+                assert.ok(false, 'The feedback should not have been displayed');
             }
             ready();
         };
 
 
-        if ( data.data ) {
-            $container.data( data.data, data.text );
+        if (data.data) {
+            $container.data(data.data, data.text);
         }
-        message( $container );
-    } );
+        message($container);
+    });
 
-} );
+});

--- a/views/js/test/tools/performances/test.html
+++ b/views/js/test/tools/performances/test.html
@@ -5,8 +5,8 @@
         <title>Test - Performances Tester</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/performances/tester"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/performances/test.js
+++ b/views/js/test/tools/performances/test.js
@@ -15,22 +15,22 @@
  *
  * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/performances/tester' ], function(  performancesTester ) {
+define(['taoClientDiagnostic/tools/performances/tester'], function(performancesTester) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.expect( 6 );
-        assert.ok( typeof performancesTester === 'function', 'The module exposes a function' );
-        assert.ok( typeof performancesTester() === 'object', 'performancesTester is a factory' );
-        assert.ok( typeof performancesTester().start === 'function', 'the test has a start method' );
-        assert.ok( typeof performancesTester().getSummary === 'function', 'the test has a getSummary method' );
-        assert.ok( typeof performancesTester().getFeedback === 'function', 'the test has a getFeedback method' );
-        assert.ok( typeof performancesTester().labels === 'object', 'the test has a labels objects' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.expect(6);
+        assert.ok(typeof performancesTester === 'function', 'The module exposes a function');
+        assert.ok(typeof performancesTester() === 'object', 'performancesTester is a factory');
+        assert.ok(typeof performancesTester().start === 'function', 'the test has a start method');
+        assert.ok(typeof performancesTester().getSummary === 'function', 'the test has a getSummary method');
+        assert.ok(typeof performancesTester().getFeedback === 'function', 'the test has a getFeedback method');
+        assert.ok(typeof performancesTester().labels === 'object', 'the test has a labels objects');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no level'
     }, {
         title: 'level 0',
@@ -44,9 +44,9 @@ define( [  'taoClientDiagnostic/tools/performances/tester' ], function(  perform
     }, {
         title: 'level 3',
         level: 3
-    } ] )
-        .test( 'labels', function( data, assert ) {
-            var labels = performancesTester( { level: data.level } ).labels;
+    }])
+        .test('labels', function(data, assert) {
+            var labels = performancesTester({level: data.level}).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -55,81 +55,81 @@ define( [  'taoClientDiagnostic/tools/performances/tester' ], function(  perform
                 'performancesAverage'
             ];
 
-            assert.expect( labelKeys.length + 1 );
+            assert.expect(labelKeys.length + 1);
 
-            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
-            labelKeys.forEach( function( key ) {
-                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
-            } );
-        } );
+            assert.equal(typeof labels, 'object', 'A set of labels is returned');
+            labelKeys.forEach(function(key) {
+                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
+            });
+        });
 
-    QUnit.test( 'getSummary', function( assert ) {
-        var tester = performancesTester( {} );
+    QUnit.test('getSummary', function(assert) {
+        var tester = performancesTester({});
         var results = {
             min: 30,
             max: 90,
             average: 60
         };
-        var summary = tester.getSummary( results );
+        var summary = tester.getSummary(results);
 
-        assert.expect( 10 );
+        assert.expect(10);
 
-        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
+        assert.equal(typeof summary, 'object', 'The method has returned the summary');
 
-        assert.equal( typeof summary.performancesMin, 'object', 'The summary contains entry for min performances' );
-        assert.equal( typeof summary.performancesMin.message, 'string', 'The summary contains label for min performances' );
-        assert.equal( summary.performancesMin.value, results.min + ' s', 'The summary contains the expected value for min performances' );
+        assert.equal(typeof summary.performancesMin, 'object', 'The summary contains entry for min performances');
+        assert.equal(typeof summary.performancesMin.message, 'string', 'The summary contains label for min performances');
+        assert.equal(summary.performancesMin.value, results.min + ' s', 'The summary contains the expected value for min performances');
 
-        assert.equal( typeof summary.performancesMax, 'object', 'The summary contains entry for max performances' );
-        assert.equal( typeof summary.performancesMax.message, 'string', 'The summary contains label for max performances' );
-        assert.equal( summary.performancesMax.value, results.max + ' s', 'The summary contains the expected value for max performances' );
+        assert.equal(typeof summary.performancesMax, 'object', 'The summary contains entry for max performances');
+        assert.equal(typeof summary.performancesMax.message, 'string', 'The summary contains label for max performances');
+        assert.equal(summary.performancesMax.value, results.max + ' s', 'The summary contains the expected value for max performances');
 
-        assert.equal( typeof summary.performancesAverage, 'object', 'The summary contains entry for average performances' );
-        assert.equal( typeof summary.performancesAverage.message, 'string', 'The summary contains label for average performances' );
-        assert.equal( summary.performancesAverage.value, results.average + ' s', 'The summary contains the expected value for average performances' );
-    } );
+        assert.equal(typeof summary.performancesAverage, 'object', 'The summary contains entry for average performances');
+        assert.equal(typeof summary.performancesAverage.message, 'string', 'The summary contains label for average performances');
+        assert.equal(summary.performancesAverage.value, results.average + ' s', 'The summary contains the expected value for average performances');
+    });
 
-    QUnit.test( 'getFeedback', function( assert ) {
+    QUnit.test('getFeedback', function(assert) {
         var optimal = 1;
         var threshold = 10;
-        var tester = performancesTester( { optimal: optimal, threshold: threshold } );
+        var tester = performancesTester({optimal: optimal, threshold: threshold});
         var result = optimal;
-        var status = tester.getFeedback( result );
+        var status = tester.getFeedback(result);
 
-        assert.expect( 6 );
+        assert.expect(6);
 
-        assert.equal( typeof status, 'object', 'The method has returned the status' );
-        assert.equal( status.id, 'performances', 'The status contains the tester id' );
-        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
-        assert.equal( typeof status.title, 'string', 'The status contains a title' );
-        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
-        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
-    } );
+        assert.equal(typeof status, 'object', 'The method has returned the status');
+        assert.equal(status.id, 'performances', 'The status contains the tester id');
+        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
+        assert.equal(typeof status.title, 'string', 'The status contains a title');
+        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
+        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
+    });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
-    QUnit.test( 'The tester runs', function( assert ) {
+    QUnit.test('The tester runs', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 10 );
+        assert.expect(10);
 
-        performancesTester( {} ).start( function( status, details, results ) {
+        performancesTester({}).start(function(status, details, results) {
             var duration = results.average;
             var toString = {}.toString;
 
-            assert.ok( typeof status === 'object', 'The status is a object' );
-            assert.ok( typeof details === 'object', 'The details is a object' );
-            assert.ok( typeof results === 'object', 'The results is a object' );
-            assert.ok( duration > 0, 'The result is a positive number' );
-            assert.ok( typeof results.min === 'number', 'The minimum speed is provided inside the details' );
-            assert.ok( typeof results.max === 'number', 'The maximum speed is provided inside the details' );
-            assert.ok( typeof results.average === 'number', 'The average speed is provided inside the details' );
-            assert.ok( typeof results.variance === 'number', 'The speed variance is provided inside the details' );
-            assert.equal( duration, results.average, 'The total duration provided inside the details must be equal to provided duration' );
-            assert.ok(toString.call( results.values ) === '[object Array]', 'The detailed measures are provided inside the details' );
+            assert.ok(typeof status === 'object', 'The status is a object');
+            assert.ok(typeof details === 'object', 'The details is a object');
+            assert.ok(typeof results === 'object', 'The results is a object');
+            assert.ok(duration > 0, 'The result is a positive number');
+            assert.ok(typeof results.min === 'number', 'The minimum speed is provided inside the details');
+            assert.ok(typeof results.max === 'number', 'The maximum speed is provided inside the details');
+            assert.ok(typeof results.average === 'number', 'The average speed is provided inside the details');
+            assert.ok(typeof results.variance === 'number', 'The speed variance is provided inside the details');
+            assert.equal(duration, results.average, 'The total duration provided inside the details must be equal to provided duration');
+            assert.ok(toString.call(results.values) === '[object Array]', 'The detailed measures are provided inside the details');
 
             ready();
-        } );
-    } );
+        });
+    });
 
-} );
+});

--- a/views/js/test/tools/performances/test.js
+++ b/views/js/test/tools/performances/test.js
@@ -15,22 +15,22 @@
  *
  * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/performances/tester'], function(performancesTester){
+define( [  'taoClientDiagnostic/tools/performances/tester' ], function(  performancesTester ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function(assert){
-        QUnit.expect(6);
-        assert.ok(typeof performancesTester === 'function', 'The module exposes a function');
-        assert.ok(typeof performancesTester() === 'object', 'performancesTester is a factory');
-        assert.ok(typeof performancesTester().start === 'function', 'the test has a start method');
-        assert.ok(typeof performancesTester().getSummary === 'function', 'the test has a getSummary method');
-        assert.ok(typeof performancesTester().getFeedback === 'function', 'the test has a getFeedback method');
-        assert.ok(typeof performancesTester().labels === 'object', 'the test has a labels objects');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.expect( 6 );
+        assert.ok( typeof performancesTester === 'function', 'The module exposes a function' );
+        assert.ok( typeof performancesTester() === 'object', 'performancesTester is a factory' );
+        assert.ok( typeof performancesTester().start === 'function', 'the test has a start method' );
+        assert.ok( typeof performancesTester().getSummary === 'function', 'the test has a getSummary method' );
+        assert.ok( typeof performancesTester().getFeedback === 'function', 'the test has a getFeedback method' );
+        assert.ok( typeof performancesTester().labels === 'object', 'the test has a labels objects' );
+    } );
 
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no level'
     }, {
         title: 'level 0',
@@ -44,9 +44,9 @@ define(['taoClientDiagnostic/tools/performances/tester'], function(performancesT
     }, {
         title: 'level 3',
         level: 3
-    }])
-        .test('labels', function(data, assert) {
-            var labels = performancesTester({level: data.level}).labels;
+    } ] )
+        .test( 'labels', function( data, assert ) {
+            var labels = performancesTester( { level: data.level } ).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -55,82 +55,81 @@ define(['taoClientDiagnostic/tools/performances/tester'], function(performancesT
                 'performancesAverage'
             ];
 
-            QUnit.expect(labelKeys.length + 1);
+            assert.expect( labelKeys.length + 1 );
 
-            assert.equal(typeof labels, 'object', 'A set of labels is returned');
-            labelKeys.forEach(function(key) {
-                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
-            });
-        });
+            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
+            labelKeys.forEach( function( key ) {
+                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
+            } );
+        } );
 
-    QUnit.test('getSummary', function(assert) {
-        var tester = performancesTester({});
+    QUnit.test( 'getSummary', function( assert ) {
+        var tester = performancesTester( {} );
         var results = {
             min: 30,
             max: 90,
             average: 60
         };
-        var summary = tester.getSummary(results);
+        var summary = tester.getSummary( results );
 
-        QUnit.expect(10);
+        assert.expect( 10 );
 
-        assert.equal(typeof summary, 'object', 'The method has returned the summary');
+        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
 
-        assert.equal(typeof summary.performancesMin, 'object', 'The summary contains entry for min performances');
-        assert.equal(typeof summary.performancesMin.message, 'string', 'The summary contains label for min performances');
-        assert.equal(summary.performancesMin.value, results.min + ' s', 'The summary contains the expected value for min performances');
+        assert.equal( typeof summary.performancesMin, 'object', 'The summary contains entry for min performances' );
+        assert.equal( typeof summary.performancesMin.message, 'string', 'The summary contains label for min performances' );
+        assert.equal( summary.performancesMin.value, results.min + ' s', 'The summary contains the expected value for min performances' );
 
-        assert.equal(typeof summary.performancesMax, 'object', 'The summary contains entry for max performances');
-        assert.equal(typeof summary.performancesMax.message, 'string', 'The summary contains label for max performances');
-        assert.equal(summary.performancesMax.value, results.max + ' s', 'The summary contains the expected value for max performances');
+        assert.equal( typeof summary.performancesMax, 'object', 'The summary contains entry for max performances' );
+        assert.equal( typeof summary.performancesMax.message, 'string', 'The summary contains label for max performances' );
+        assert.equal( summary.performancesMax.value, results.max + ' s', 'The summary contains the expected value for max performances' );
 
-        assert.equal(typeof summary.performancesAverage, 'object', 'The summary contains entry for average performances');
-        assert.equal(typeof summary.performancesAverage.message, 'string', 'The summary contains label for average performances');
-        assert.equal(summary.performancesAverage.value, results.average + ' s', 'The summary contains the expected value for average performances');
-    });
+        assert.equal( typeof summary.performancesAverage, 'object', 'The summary contains entry for average performances' );
+        assert.equal( typeof summary.performancesAverage.message, 'string', 'The summary contains label for average performances' );
+        assert.equal( summary.performancesAverage.value, results.average + ' s', 'The summary contains the expected value for average performances' );
+    } );
 
-    QUnit.test('getFeedback', function(assert) {
+    QUnit.test( 'getFeedback', function( assert ) {
         var optimal = 1;
         var threshold = 10;
-        var tester = performancesTester({optimal: optimal, threshold: threshold});
+        var tester = performancesTester( { optimal: optimal, threshold: threshold } );
         var result = optimal;
-        var status = tester.getFeedback(result);
+        var status = tester.getFeedback( result );
 
-        QUnit.expect(6);
+        assert.expect( 6 );
 
-        assert.equal(typeof status, 'object', 'The method has returned the status');
-        assert.equal(status.id, 'performances', 'The status contains the tester id');
-        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
-        assert.equal(typeof status.title, 'string', 'The status contains a title');
-        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
-        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
-    });
+        assert.equal( typeof status, 'object', 'The method has returned the status' );
+        assert.equal( status.id, 'performances', 'The status contains the tester id' );
+        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
+        assert.equal( typeof status.title, 'string', 'The status contains a title' );
+        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
+        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
+    } );
 
+    QUnit.module( 'Test' );
 
-    QUnit.module('Test');
+    QUnit.test( 'The tester runs', function( assert ) {
+        var ready = assert.async();
 
-    QUnit.asyncTest('The tester runs', function(assert){
+        assert.expect( 10 );
 
-        QUnit.expect(10);
-
-        performancesTester({}).start(function(status, details, results) {
+        performancesTester( {} ).start( function( status, details, results ) {
             var duration = results.average;
             var toString = {}.toString;
 
-            assert.ok(typeof status === 'object', 'The status is a object');
-            assert.ok(typeof details === 'object', 'The details is a object');
-            assert.ok(typeof results === 'object', 'The results is a object');
-            assert.ok(duration > 0, 'The result is a positive number');
-            assert.ok(typeof results.min === 'number', 'The minimum speed is provided inside the details');
-            assert.ok(typeof results.max === 'number', 'The maximum speed is provided inside the details');
-            assert.ok(typeof results.average === 'number', 'The average speed is provided inside the details');
-            assert.ok(typeof results.variance === 'number', 'The speed variance is provided inside the details');
-            assert.equal(duration, results.average, 'The total duration provided inside the details must be equal to provided duration');
-            assert.ok(toString.call(results.values) === '[object Array]', 'The detailed measures are provided inside the details');
+            assert.ok( typeof status === 'object', 'The status is a object' );
+            assert.ok( typeof details === 'object', 'The details is a object' );
+            assert.ok( typeof results === 'object', 'The results is a object' );
+            assert.ok( duration > 0, 'The result is a positive number' );
+            assert.ok( typeof results.min === 'number', 'The minimum speed is provided inside the details' );
+            assert.ok( typeof results.max === 'number', 'The maximum speed is provided inside the details' );
+            assert.ok( typeof results.average === 'number', 'The average speed is provided inside the details' );
+            assert.ok( typeof results.variance === 'number', 'The speed variance is provided inside the details' );
+            assert.equal( duration, results.average, 'The total duration provided inside the details must be equal to provided duration' );
+            assert.ok(toString.call( results.values ) === '[object Array]', 'The detailed measures are provided inside the details' );
 
-            QUnit.start();
-        });
+            ready();
+        } );
+    } );
 
-    });
-
-});
+} );

--- a/views/js/test/tools/screen/test.html
+++ b/views/js/test/tools/screen/test.html
@@ -5,8 +5,8 @@
         <title>Test - Screen Tester</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/screen/tester"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/screen/test.js
+++ b/views/js/test/tools/screen/test.js
@@ -15,22 +15,22 @@
  *
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/screen/tester' ], function(  screenTester ) {
+define(['taoClientDiagnostic/tools/screen/tester'], function(screenTester) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.expect( 6 );
-        assert.ok( typeof screenTester === 'function', 'The module exposes a function' );
-        assert.ok( typeof screenTester() === 'object', 'screenTester is a factory' );
-        assert.ok( typeof screenTester().start === 'function', 'the test has a start method' );
-        assert.ok( typeof screenTester().getSummary === 'function', 'the test has a getSummary method' );
-        assert.ok( typeof screenTester().getFeedback === 'function', 'the test has a getFeedback method' );
-        assert.ok( typeof screenTester().labels === 'object', 'the test has a labels objects' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.expect(6);
+        assert.ok(typeof screenTester === 'function', 'The module exposes a function');
+        assert.ok(typeof screenTester() === 'object', 'screenTester is a factory');
+        assert.ok(typeof screenTester().start === 'function', 'the test has a start method');
+        assert.ok(typeof screenTester().getSummary === 'function', 'the test has a getSummary method');
+        assert.ok(typeof screenTester().getFeedback === 'function', 'the test has a getFeedback method');
+        assert.ok(typeof screenTester().labels === 'object', 'the test has a labels objects');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no level'
     }, {
         title: 'level 0',
@@ -44,9 +44,9 @@ define( [  'taoClientDiagnostic/tools/screen/tester' ], function(  screenTester 
     }, {
         title: 'level 3',
         level: 3
-    } ] )
-        .test( 'labels', function( data, assert ) {
-            var labels = screenTester( { level: data.level } ).labels;
+    }])
+        .test('labels', function(data, assert) {
+            var labels = screenTester({level: data.level}).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -54,36 +54,36 @@ define( [  'taoClientDiagnostic/tools/screen/tester' ], function(  screenTester 
                 'height'
             ];
 
-            assert.expect( labelKeys.length + 1 );
+            assert.expect(labelKeys.length + 1);
 
-            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
-            labelKeys.forEach( function( key ) {
-                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
-            } );
-        } );
+            assert.equal(typeof labels, 'object', 'A set of labels is returned');
+            labelKeys.forEach(function(key) {
+                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
+            });
+        });
 
-    QUnit.test( 'getSummary', function( assert ) {
-        var tester = screenTester( {} );
+    QUnit.test('getSummary', function(assert) {
+        var tester = screenTester({});
         var results = {
             width: 1280,
             height: 1024
         };
-        var summary = tester.getSummary( results );
+        var summary = tester.getSummary(results);
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
+        assert.equal(typeof summary, 'object', 'The method has returned the summary');
 
-        assert.equal( typeof summary.width, 'object', 'The summary contains entry for the screen width' );
-        assert.equal( typeof summary.width.message, 'string', 'The summary contains label for the screen width' );
-        assert.equal( summary.width.value, results.width, 'The summary contains the expected value for the screen width' );
+        assert.equal(typeof summary.width, 'object', 'The summary contains entry for the screen width');
+        assert.equal(typeof summary.width.message, 'string', 'The summary contains label for the screen width');
+        assert.equal(summary.width.value, results.width, 'The summary contains the expected value for the screen width');
 
-        assert.equal( typeof summary.height, 'object', 'The summary contains entry for the screen height' );
-        assert.equal( typeof summary.height.message, 'string', 'The summary contains label for the screen height' );
-        assert.equal( summary.height.value, results.height, 'The summary contains the expected value for the screen height' );
-    } );
+        assert.equal(typeof summary.height, 'object', 'The summary contains entry for the screen height');
+        assert.equal(typeof summary.height.message, 'string', 'The summary contains label for the screen height');
+        assert.equal(summary.height.value, results.height, 'The summary contains the expected value for the screen height');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'requirements not met (width)',
         threshold: {
             width: 1024,
@@ -131,38 +131,38 @@ define( [  'taoClientDiagnostic/tools/screen/tester' ], function(  screenTester 
         },
         percentage: 100,
         type: 'success'
-    } ] )
-        .test( 'getFeedback', function( data, assert ) {
-            var tester = screenTester( { threshold: data.threshold } );
-            var status = tester.getFeedback( data.results );
+    }])
+        .test('getFeedback', function(data, assert) {
+            var tester = screenTester({threshold: data.threshold});
+            var status = tester.getFeedback(data.results);
 
-            assert.expect( 6 );
+            assert.expect(6);
 
-            assert.equal( typeof status, 'object', 'The method has returned the status' );
-            assert.equal( status.id, 'screen', 'The status contains the tester id' );
-            assert.equal( status.percentage, data.percentage, 'The status contains the expected percentage' );
-            assert.equal( typeof status.title, 'string', 'The status contains a title' );
-            assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
-            assert.equal( status.feedback.type, data.type, 'The status contains the expected feedback type' );
-        } );
+            assert.equal(typeof status, 'object', 'The method has returned the status');
+            assert.equal(status.id, 'screen', 'The status contains the tester id');
+            assert.equal(status.percentage, data.percentage, 'The status contains the expected percentage');
+            assert.equal(typeof status.title, 'string', 'The status contains a title');
+            assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
+            assert.equal(status.feedback.type, data.type, 'The status contains the expected feedback type');
+        });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
-    QUnit.test( 'The tester runs', function( assert ) {
+    QUnit.test('The tester runs', function(assert) {
         var ready = assert.async();
 
-        assert.expect( 5 );
+        assert.expect(5);
 
-        screenTester( {} ).start( function( status, details, results ) {
+        screenTester({}).start(function(status, details, results) {
 
-            assert.equal( typeof status, 'object', 'The status is an object' );
-            assert.equal( typeof details, 'object', 'The details is an object' );
-            assert.equal( typeof results, 'object', 'The details are provided inside an object' );
-            assert.equal( results.width, window.screen.width, 'The screen width is provided' );
-            assert.equal( results.height, window.screen.height, 'The screen height is provided' );
+            assert.equal(typeof status, 'object', 'The status is an object');
+            assert.equal(typeof details, 'object', 'The details is an object');
+            assert.equal(typeof results, 'object', 'The details are provided inside an object');
+            assert.equal(results.width, window.screen.width, 'The screen width is provided');
+            assert.equal(results.height, window.screen.height, 'The screen height is provided');
 
             ready();
-        } );
-    } );
+        });
+    });
 
-} );
+});

--- a/views/js/test/tools/screen/test.js
+++ b/views/js/test/tools/screen/test.js
@@ -15,25 +15,22 @@
  *
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
  */
-define([
-    'taoClientDiagnostic/tools/screen/tester'
-], function (screenTester) {
+define( [  'taoClientDiagnostic/tools/screen/tester' ], function(  screenTester ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function (assert) {
-        QUnit.expect(6);
-        assert.ok(typeof screenTester === 'function', 'The module exposes a function');
-        assert.ok(typeof screenTester() === 'object', 'screenTester is a factory');
-        assert.ok(typeof screenTester().start === 'function', 'the test has a start method');
-        assert.ok(typeof screenTester().getSummary === 'function', 'the test has a getSummary method');
-        assert.ok(typeof screenTester().getFeedback === 'function', 'the test has a getFeedback method');
-        assert.ok(typeof screenTester().labels === 'object', 'the test has a labels objects');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.expect( 6 );
+        assert.ok( typeof screenTester === 'function', 'The module exposes a function' );
+        assert.ok( typeof screenTester() === 'object', 'screenTester is a factory' );
+        assert.ok( typeof screenTester().start === 'function', 'the test has a start method' );
+        assert.ok( typeof screenTester().getSummary === 'function', 'the test has a getSummary method' );
+        assert.ok( typeof screenTester().getFeedback === 'function', 'the test has a getFeedback method' );
+        assert.ok( typeof screenTester().labels === 'object', 'the test has a labels objects' );
+    } );
 
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no level'
     }, {
         title: 'level 0',
@@ -47,9 +44,9 @@ define([
     }, {
         title: 'level 3',
         level: 3
-    }])
-        .test('labels', function (data, assert) {
-            var labels = screenTester({level: data.level}).labels;
+    } ] )
+        .test( 'labels', function( data, assert ) {
+            var labels = screenTester( { level: data.level } ).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -57,38 +54,36 @@ define([
                 'height'
             ];
 
-            QUnit.expect(labelKeys.length + 1);
+            assert.expect( labelKeys.length + 1 );
 
-            assert.equal(typeof labels, 'object', 'A set of labels is returned');
-            labelKeys.forEach(function (key) {
-                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
-            });
-        });
+            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
+            labelKeys.forEach( function( key ) {
+                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
+            } );
+        } );
 
-
-    QUnit.test('getSummary', function(assert) {
-        var tester = screenTester({});
+    QUnit.test( 'getSummary', function( assert ) {
+        var tester = screenTester( {} );
         var results = {
             width: 1280,
             height: 1024
         };
-        var summary = tester.getSummary(results);
+        var summary = tester.getSummary( results );
 
-        QUnit.expect(7);
+        assert.expect( 7 );
 
-        assert.equal(typeof summary, 'object', 'The method has returned the summary');
+        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
 
-        assert.equal(typeof summary.width, 'object', 'The summary contains entry for the screen width');
-        assert.equal(typeof summary.width.message, 'string', 'The summary contains label for the screen width');
-        assert.equal(summary.width.value, results.width, 'The summary contains the expected value for the screen width');
+        assert.equal( typeof summary.width, 'object', 'The summary contains entry for the screen width' );
+        assert.equal( typeof summary.width.message, 'string', 'The summary contains label for the screen width' );
+        assert.equal( summary.width.value, results.width, 'The summary contains the expected value for the screen width' );
 
-        assert.equal(typeof summary.height, 'object', 'The summary contains entry for the screen height');
-        assert.equal(typeof summary.height.message, 'string', 'The summary contains label for the screen height');
-        assert.equal(summary.height.value, results.height, 'The summary contains the expected value for the screen height');
-    });
+        assert.equal( typeof summary.height, 'object', 'The summary contains entry for the screen height' );
+        assert.equal( typeof summary.height.message, 'string', 'The summary contains label for the screen height' );
+        assert.equal( summary.height.value, results.height, 'The summary contains the expected value for the screen height' );
+    } );
 
-
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'requirements not met (width)',
         threshold: {
             width: 1024,
@@ -136,41 +131,38 @@ define([
         },
         percentage: 100,
         type: 'success'
-    }])
-        .test('getFeedback', function (data, assert) {
-            var tester = screenTester({threshold: data.threshold});
-            var status = tester.getFeedback(data.results);
+    } ] )
+        .test( 'getFeedback', function( data, assert ) {
+            var tester = screenTester( { threshold: data.threshold } );
+            var status = tester.getFeedback( data.results );
 
-            QUnit.expect(6);
+            assert.expect( 6 );
 
-            assert.equal(typeof status, 'object', 'The method has returned the status');
-            assert.equal(status.id, 'screen', 'The status contains the tester id');
-            assert.equal(status.percentage, data.percentage, 'The status contains the expected percentage');
-            assert.equal(typeof status.title, 'string', 'The status contains a title');
-            assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
-            assert.equal(status.feedback.type, data.type, 'The status contains the expected feedback type');
-        });
+            assert.equal( typeof status, 'object', 'The method has returned the status' );
+            assert.equal( status.id, 'screen', 'The status contains the tester id' );
+            assert.equal( status.percentage, data.percentage, 'The status contains the expected percentage' );
+            assert.equal( typeof status.title, 'string', 'The status contains a title' );
+            assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
+            assert.equal( status.feedback.type, data.type, 'The status contains the expected feedback type' );
+        } );
 
+    QUnit.module( 'Test' );
 
-    QUnit.module('Test');
+    QUnit.test( 'The tester runs', function( assert ) {
+        var ready = assert.async();
 
+        assert.expect( 5 );
 
-    QUnit.asyncTest('The tester runs', function (assert) {
+        screenTester( {} ).start( function( status, details, results ) {
 
-        QUnit.expect(5);
+            assert.equal( typeof status, 'object', 'The status is an object' );
+            assert.equal( typeof details, 'object', 'The details is an object' );
+            assert.equal( typeof results, 'object', 'The details are provided inside an object' );
+            assert.equal( results.width, window.screen.width, 'The screen width is provided' );
+            assert.equal( results.height, window.screen.height, 'The screen height is provided' );
 
-        screenTester({}).start(function (status, details, results) {
+            ready();
+        } );
+    } );
 
-            assert.equal(typeof status, 'object', 'The status is an object');
-            assert.equal(typeof details, 'object', 'The details is an object');
-            assert.equal(typeof results, 'object', 'The details are provided inside an object');
-            assert.equal(results.width, window.screen.width, 'The screen width is provided');
-            assert.equal(results.height, window.screen.height, 'The screen height is provided');
-
-            QUnit.start();
-        });
-
-    });
-
-
-});
+} );

--- a/views/js/test/tools/stats/test.html
+++ b/views/js/test/tools/stats/test.html
@@ -5,8 +5,8 @@
         <title>Test - Stats</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/stats"></script>
         <script  type="text/javascript">

--- a/views/js/test/tools/stats/test.js
+++ b/views/js/test/tools/stats/test.js
@@ -15,7 +15,7 @@
  *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  */
-define(['taoClientDiagnostic/tools/stats'], function(stats){
+define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
     'use strict';
 
     var listValuesArray;
@@ -25,373 +25,372 @@ define(['taoClientDiagnostic/tools/stats'], function(stats){
     var listValuesCollectionCallbackDataProvider;
     var listValuesObjectCallbackDataProvider;
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function(assert){
-        assert.ok(typeof stats === 'function', 'The module exposes a function');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.ok( typeof stats === 'function', 'The module exposes a function' );
+    } );
 
+    QUnit.module( 'Test' );
 
-    QUnit.module('Test');
+    /** Stats from a collection **/
+    listValuesArray = [ {
+        'totalDuration': 64,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 62
+    }, {
+        'totalDuration': 75,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 73
+    }, {
+        'totalDuration': 58,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 56
+    }, {
+        'totalDuration': 64,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 62
+    }, {
+        'totalDuration': 73,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 71
+    }, {
+        'totalDuration': 72,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 70
+    }, {
+        'totalDuration': 52,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 50
+    }, {
+        'totalDuration': 71,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 69
+    }, {
+        'totalDuration': 74,
+        'networkDuration': 1,
+        'requestDuration': 1,
+        'displayDuration': 72
+    } ];
 
-    /** stats from a collection **/
-    listValuesArray = [{
-        "totalDuration": 64,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 62
+    listValuesCollectionDataProvider = [ {
+        title: 'min',
+        name: 'min',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 50
     }, {
-        "totalDuration": 75,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 73
+        title: 'max',
+        name: 'max',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 73
     }, {
-        "totalDuration": 58,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 56
+        title: 'sum',
+        name: 'sum',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 585
     }, {
-        "totalDuration": 64,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 62
+        title: 'count',
+        name: 'count',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: listValuesArray.length
     }, {
-        "totalDuration": 73,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 71
+        title: 'average',
+        name: 'average',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 65
     }, {
-        "totalDuration": 72,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 70
+        title: 'median',
+        name: 'median',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 69.5
     }, {
-        "totalDuration": 52,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 50
+        title: 'variance',
+        name: 'variance',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: 8.02
     }, {
-        "totalDuration": 71,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 69
-    }, {
-        "totalDuration": 74,
-        "networkDuration": 1,
-        "requestDuration": 1,
-        "displayDuration": 72
-    }];
-
-    listValuesCollectionDataProvider = [{
-        title : 'min',
-        name : 'min',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 50
-    }, {
-        title : 'max',
-        name : 'max',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 73
-    }, {
-        title : 'sum',
-        name : 'sum',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 585
-    }, {
-        title : 'count',
-        name : 'count',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : listValuesArray.length
-    }, {
-        title : 'average',
-        name : 'average',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 65
-    }, {
-        title : 'median',
-        name : 'median',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 69.5
-    }, {
-        title : 'variance',
-        name : 'variance',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : 8.02
-    }, {
-        title : 'values',
-        name : 'values',
-        input : listValuesArray,
-        field : 'displayDuration',
-        expected : listValuesArray
-    }];
+        title: 'values',
+        name: 'values',
+        input: listValuesArray,
+        field: 'displayDuration',
+        expected: listValuesArray
+    } ];
 
     QUnit
-        .cases(listValuesCollectionDataProvider)
-        .test('Stats on a collection', function(data, assert) {
-            var results = stats(data.input, data.field);
-            var value = results[data.name];
-            if ('number' === typeof value) {
-                value = Math.round(value * 100) / 100;
+        .cases.init( listValuesCollectionDataProvider )
+        .test( 'Stats on a collection', function( data, assert ) {
+            var results = stats( data.input, data.field );
+            var value = results[ data.name ];
+            if ( 'number' === typeof value ) {
+                value = Math.round( value * 100 ) / 100;
             }
-            QUnit.expect(1);
-            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
-        });
+            assert.expect( 1 );
+            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
+        } );
 
-    /** stats from an object **/
+    /** Stats from an object **/
     listValuesObject = {
-         "sample0": {
-             "totalDuration": 64,
-             "networkDuration": 1,
-             "requestDuration": 1,
-             "displayDuration": 62
+         'sample0': {
+             'totalDuration': 64,
+             'networkDuration': 1,
+             'requestDuration': 1,
+             'displayDuration': 62
          },
-        "sample1": {
-            "totalDuration": 75,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 73
+        'sample1': {
+            'totalDuration': 75,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 73
         },
-        "sample2": {
-            "totalDuration": 58,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 56
+        'sample2': {
+            'totalDuration': 58,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 56
         },
-        "sample3": {
-            "totalDuration": 64,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 62
+        'sample3': {
+            'totalDuration': 64,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 62
         },
-        "sample4": {
-            "totalDuration": 73,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 71
+        'sample4': {
+            'totalDuration': 73,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 71
         },
-        "sample5": {
-            "totalDuration": 72,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 70
+        'sample5': {
+            'totalDuration': 72,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 70
         },
-        "sample6": {
-            "totalDuration": 52,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 50
+        'sample6': {
+            'totalDuration': 52,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 50
         },
-        "sample7": {
-            "totalDuration": 71,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 69
+        'sample7': {
+            'totalDuration': 71,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 69
         },
-        "sample8": {
-            "totalDuration": 74,
-            "networkDuration": 1,
-            "requestDuration": 1,
-            "displayDuration": 72
+        'sample8': {
+            'totalDuration': 74,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 72
         }
     };
 
-    listValuesObjectDataProvider = [{
-        title : 'min',
-        name : 'min',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 50
+    listValuesObjectDataProvider = [ {
+        title: 'min',
+        name: 'min',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 50
     }, {
-        title : 'max',
-        name : 'max',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 73
+        title: 'max',
+        name: 'max',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 73
     }, {
-        title : 'sum',
-        name : 'sum',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 585
+        title: 'sum',
+        name: 'sum',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 585
     }, {
-        title : 'count',
-        name : 'count',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 9
+        title: 'count',
+        name: 'count',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 9
     }, {
-        title : 'average',
-        name : 'average',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 65
+        title: 'average',
+        name: 'average',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 65
     }, {
-        title : 'median',
-        name : 'median',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 69.5
+        title: 'median',
+        name: 'median',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 69.5
     }, {
-        title : 'variance',
-        name : 'variance',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : 8.02
+        title: 'variance',
+        name: 'variance',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: 8.02
     }, {
-        title : 'values',
-        name : 'values',
-        input : listValuesObject,
-        field : 'displayDuration',
-        expected : listValuesObject
-    }];
+        title: 'values',
+        name: 'values',
+        input: listValuesObject,
+        field: 'displayDuration',
+        expected: listValuesObject
+    } ];
 
     QUnit
-        .cases(listValuesObjectDataProvider)
-        .test('Stats on an object', function(data, assert) {
-            var results = stats(data.input, data.field);
-            var value = results[data.name];
-            if ('number' === typeof value) {
-                value = Math.round(value * 100) / 100;
+        .cases.init( listValuesObjectDataProvider )
+        .test( 'Stats on an object', function( data, assert ) {
+            var results = stats( data.input, data.field );
+            var value = results[ data.name ];
+            if ( 'number' === typeof value ) {
+                value = Math.round( value * 100 ) / 100;
             }
-            QUnit.expect(1);
-            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
-        });
+            assert.expect( 1 );
+            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
+        } );
 
-    function getValue(value) {
+    function getValue( value ) {
         return value.displayDuration;
     }
 
-    /** stats from a collection using a callback **/
-    listValuesCollectionCallbackDataProvider = [{
-        title : 'min',
-        name : 'min',
-        input : listValuesArray,
-        field : getValue,
-        expected : 50
+    /** Stats from a collection using a callback **/
+    listValuesCollectionCallbackDataProvider = [ {
+        title: 'min',
+        name: 'min',
+        input: listValuesArray,
+        field: getValue,
+        expected: 50
     }, {
-        title : 'max',
-        name : 'max',
-        input : listValuesArray,
-        field : getValue,
-        expected : 73
+        title: 'max',
+        name: 'max',
+        input: listValuesArray,
+        field: getValue,
+        expected: 73
     }, {
-        title : 'sum',
-        name : 'sum',
-        input : listValuesArray,
-        field : getValue,
-        expected : 585
+        title: 'sum',
+        name: 'sum',
+        input: listValuesArray,
+        field: getValue,
+        expected: 585
     }, {
-        title : 'count',
-        name : 'count',
-        input : listValuesArray,
-        field : getValue,
-        expected : listValuesArray.length
+        title: 'count',
+        name: 'count',
+        input: listValuesArray,
+        field: getValue,
+        expected: listValuesArray.length
     }, {
-        title : 'average',
-        name : 'average',
-        input : listValuesArray,
-        field : getValue,
-        expected : 65
+        title: 'average',
+        name: 'average',
+        input: listValuesArray,
+        field: getValue,
+        expected: 65
     }, {
-        title : 'median',
-        name : 'median',
-        input : listValuesArray,
-        field : getValue,
-        expected : 69.5
+        title: 'median',
+        name: 'median',
+        input: listValuesArray,
+        field: getValue,
+        expected: 69.5
     }, {
-        title : 'variance',
-        name : 'variance',
-        input : listValuesArray,
-        field : getValue,
-        expected : 8.02
+        title: 'variance',
+        name: 'variance',
+        input: listValuesArray,
+        field: getValue,
+        expected: 8.02
     }, {
-        title : 'values',
-        name : 'values',
-        input : listValuesArray,
-        field : getValue,
-        expected : listValuesArray
-    }];
+        title: 'values',
+        name: 'values',
+        input: listValuesArray,
+        field: getValue,
+        expected: listValuesArray
+    } ];
 
     QUnit
-        .cases(listValuesCollectionCallbackDataProvider)
-        .test('Stats on a collection using a callback', function(data, assert) {
-            var results = stats(data.input, data.field);
-            var value = results[data.name];
-            if ('number' === typeof value) {
-                value = Math.round(value * 100) / 100;
+        .cases.init( listValuesCollectionCallbackDataProvider )
+        .test( 'Stats on a collection using a callback', function( data, assert ) {
+            var results = stats( data.input, data.field );
+            var value = results[ data.name ];
+            if ( 'number' === typeof value ) {
+                value = Math.round( value * 100 ) / 100;
             }
-            QUnit.expect(1);
-            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
-        });
+            assert.expect( 1 );
+            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
+        } );
 
-    /** stats from an object **/
-    listValuesObjectCallbackDataProvider = [{
-        title : 'min',
-        name : 'min',
-        input : listValuesObject,
-        field : getValue,
-        expected : 50
+    /** Stats from an object **/
+    listValuesObjectCallbackDataProvider = [ {
+        title: 'min',
+        name: 'min',
+        input: listValuesObject,
+        field: getValue,
+        expected: 50
     }, {
-        title : 'max',
-        name : 'max',
-        input : listValuesObject,
-        field : getValue,
-        expected : 73
+        title: 'max',
+        name: 'max',
+        input: listValuesObject,
+        field: getValue,
+        expected: 73
     }, {
-        title : 'sum',
-        name : 'sum',
-        input : listValuesObject,
-        field : getValue,
-        expected : 585
+        title: 'sum',
+        name: 'sum',
+        input: listValuesObject,
+        field: getValue,
+        expected: 585
     }, {
-        title : 'count',
-        name : 'count',
-        input : listValuesObject,
-        field : getValue,
-        expected : 9
+        title: 'count',
+        name: 'count',
+        input: listValuesObject,
+        field: getValue,
+        expected: 9
     }, {
-        title : 'average',
-        name : 'average',
-        input : listValuesObject,
-        field : getValue,
-        expected : 65
+        title: 'average',
+        name: 'average',
+        input: listValuesObject,
+        field: getValue,
+        expected: 65
     }, {
-        title : 'median',
-        name : 'median',
-        input : listValuesObject,
-        field : getValue,
-        expected : 69.5
+        title: 'median',
+        name: 'median',
+        input: listValuesObject,
+        field: getValue,
+        expected: 69.5
     }, {
-        title : 'variance',
-        name : 'variance',
-        input : listValuesObject,
-        field : getValue,
-        expected : 8.02
+        title: 'variance',
+        name: 'variance',
+        input: listValuesObject,
+        field: getValue,
+        expected: 8.02
     }, {
-        title : 'values',
-        name : 'values',
-        input : listValuesObject,
-        field : getValue,
-        expected : listValuesObject
-    }];
+        title: 'values',
+        name: 'values',
+        input: listValuesObject,
+        field: getValue,
+        expected: listValuesObject
+    } ];
 
     QUnit
-        .cases(listValuesObjectCallbackDataProvider)
-        .test('Stats on an object using a callback', function(data, assert) {
-            var results = stats(data.input, data.field);
-            var value = results[data.name];
-            if ('number' === typeof value) {
-                value = Math.round(value * 100) / 100;
+        .cases.init( listValuesObjectCallbackDataProvider )
+        .test( 'Stats on an object using a callback', function( data, assert ) {
+            var results = stats( data.input, data.field );
+            var value = results[ data.name ];
+            if ( 'number' === typeof value ) {
+                value = Math.round( value * 100 ) / 100;
             }
-            QUnit.expect(1);
-            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
-        });
+            assert.expect( 1 );
+            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
+        } );
 
-});
+} );

--- a/views/js/test/tools/stats/test.js
+++ b/views/js/test/tools/stats/test.js
@@ -15,7 +15,7 @@
  *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  */
-define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
+define(['taoClientDiagnostic/tools/stats'], function(stats) {
     'use strict';
 
     var listValuesArray;
@@ -25,16 +25,16 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
     var listValuesCollectionCallbackDataProvider;
     var listValuesObjectCallbackDataProvider;
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.ok( typeof stats === 'function', 'The module exposes a function' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.ok(typeof stats === 'function', 'The module exposes a function');
+    });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
     /** Stats from a collection **/
-    listValuesArray = [ {
+    listValuesArray = [{
         'totalDuration': 64,
         'networkDuration': 1,
         'requestDuration': 1,
@@ -79,9 +79,9 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         'networkDuration': 1,
         'requestDuration': 1,
         'displayDuration': 72
-    } ];
+    }];
 
-    listValuesCollectionDataProvider = [ {
+    listValuesCollectionDataProvider = [{
         title: 'min',
         name: 'min',
         input: listValuesArray,
@@ -129,28 +129,28 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         input: listValuesArray,
         field: 'displayDuration',
         expected: listValuesArray
-    } ];
+    }];
 
     QUnit
-        .cases.init( listValuesCollectionDataProvider )
-        .test( 'Stats on a collection', function( data, assert ) {
-            var results = stats( data.input, data.field );
-            var value = results[ data.name ];
-            if ( 'number' === typeof value ) {
-                value = Math.round( value * 100 ) / 100;
+        .cases.init(listValuesCollectionDataProvider)
+        .test('Stats on a collection', function(data, assert) {
+            var results = stats(data.input, data.field);
+            var value = results[data.name];
+            if ('number' === typeof value) {
+                value = Math.round(value * 100) / 100;
             }
-            assert.expect( 1 );
-            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
-        } );
+            assert.expect(1);
+            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
+        });
 
     /** Stats from an object **/
     listValuesObject = {
-         'sample0': {
-             'totalDuration': 64,
-             'networkDuration': 1,
-             'requestDuration': 1,
-             'displayDuration': 62
-         },
+        'sample0': {
+            'totalDuration': 64,
+            'networkDuration': 1,
+            'requestDuration': 1,
+            'displayDuration': 62
+        },
         'sample1': {
             'totalDuration': 75,
             'networkDuration': 1,
@@ -201,7 +201,7 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         }
     };
 
-    listValuesObjectDataProvider = [ {
+    listValuesObjectDataProvider = [{
         title: 'min',
         name: 'min',
         input: listValuesObject,
@@ -249,26 +249,26 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         input: listValuesObject,
         field: 'displayDuration',
         expected: listValuesObject
-    } ];
+    }];
 
     QUnit
-        .cases.init( listValuesObjectDataProvider )
-        .test( 'Stats on an object', function( data, assert ) {
-            var results = stats( data.input, data.field );
-            var value = results[ data.name ];
-            if ( 'number' === typeof value ) {
-                value = Math.round( value * 100 ) / 100;
+        .cases.init(listValuesObjectDataProvider)
+        .test('Stats on an object', function(data, assert) {
+            var results = stats(data.input, data.field);
+            var value = results[data.name];
+            if ('number' === typeof value) {
+                value = Math.round(value * 100) / 100;
             }
-            assert.expect( 1 );
-            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
-        } );
+            assert.expect(1);
+            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
+        });
 
-    function getValue( value ) {
+    function getValue(value) {
         return value.displayDuration;
     }
 
     /** Stats from a collection using a callback **/
-    listValuesCollectionCallbackDataProvider = [ {
+    listValuesCollectionCallbackDataProvider = [{
         title: 'min',
         name: 'min',
         input: listValuesArray,
@@ -316,22 +316,22 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         input: listValuesArray,
         field: getValue,
         expected: listValuesArray
-    } ];
+    }];
 
     QUnit
-        .cases.init( listValuesCollectionCallbackDataProvider )
-        .test( 'Stats on a collection using a callback', function( data, assert ) {
-            var results = stats( data.input, data.field );
-            var value = results[ data.name ];
-            if ( 'number' === typeof value ) {
-                value = Math.round( value * 100 ) / 100;
+        .cases.init(listValuesCollectionCallbackDataProvider)
+        .test('Stats on a collection using a callback', function(data, assert) {
+            var results = stats(data.input, data.field);
+            var value = results[data.name];
+            if ('number' === typeof value) {
+                value = Math.round(value * 100) / 100;
             }
-            assert.expect( 1 );
-            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
-        } );
+            assert.expect(1);
+            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
+        });
 
     /** Stats from an object **/
-    listValuesObjectCallbackDataProvider = [ {
+    listValuesObjectCallbackDataProvider = [{
         title: 'min',
         name: 'min',
         input: listValuesObject,
@@ -379,18 +379,18 @@ define( [  'taoClientDiagnostic/tools/stats' ], function(  stats ) {
         input: listValuesObject,
         field: getValue,
         expected: listValuesObject
-    } ];
+    }];
 
     QUnit
-        .cases.init( listValuesObjectCallbackDataProvider )
-        .test( 'Stats on an object using a callback', function( data, assert ) {
-            var results = stats( data.input, data.field );
-            var value = results[ data.name ];
-            if ( 'number' === typeof value ) {
-                value = Math.round( value * 100 ) / 100;
+        .cases.init(listValuesObjectCallbackDataProvider)
+        .test('Stats on an object using a callback', function(data, assert) {
+            var results = stats(data.input, data.field);
+            var value = results[data.name];
+            if ('number' === typeof value) {
+                value = Math.round(value * 100) / 100;
             }
-            assert.expect( 1 );
-            assert.strictEqual( value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!' );
-        } );
+            assert.expect(1);
+            assert.strictEqual(value, data.expected, 'The value of the result field ' + data.name + ' must be equal to expected value!');
+        });
 
-} );
+});

--- a/views/js/test/tools/upload/test.html
+++ b/views/js/test/tools/upload/test.html
@@ -5,8 +5,8 @@
         <title>Test - Upload speed Tester</title>
         <base href="../../../../../../tao/views/" />
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="js/tools/upload/tester.js"></script>
         <script type="text/javascript">

--- a/views/js/test/tools/upload/test.js
+++ b/views/js/test/tools/upload/test.js
@@ -15,36 +15,37 @@
  *
  * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+
     'jquery',
     'lodash',
     'taoClientDiagnostic/tools/upload/tester'
-], function($, _, uploadTester){
+], function(  $, _, uploadTester ) {
     'use strict';
 
-    // backup/restore ajax method between each test
+    // Backup/restore ajax method between each test
     var ajaxBackup;
 
-    QUnit.testStart(function () {
+    QUnit.testStart( function() {
         ajaxBackup = $.ajax;
-    });
-    QUnit.testDone(function () {
+    } );
+    QUnit.testDone( function() {
         $.ajax = ajaxBackup;
-    });
+    } );
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('The tester has the right form', function(assert) {
-        QUnit.expect(6);
-        assert.ok(typeof uploadTester === 'function', 'The module exposes a function');
-        assert.ok(typeof uploadTester() === 'object', 'uploadTester is a factory');
-        assert.ok(typeof uploadTester().start === 'function', 'the test has a start method');
-        assert.ok(typeof uploadTester().getSummary === 'function', 'the test has a getSummary method');
-        assert.ok(typeof uploadTester().getFeedback === 'function', 'the test has a getFeedback method');
-        assert.ok(typeof uploadTester().labels === 'object', 'the test has a labels objects');
-    });
+    QUnit.test( 'The tester has the right form', function( assert ) {
+        assert.expect( 6 );
+        assert.ok( typeof uploadTester === 'function', 'The module exposes a function' );
+        assert.ok( typeof uploadTester() === 'object', 'uploadTester is a factory' );
+        assert.ok( typeof uploadTester().start === 'function', 'the test has a start method' );
+        assert.ok( typeof uploadTester().getSummary === 'function', 'the test has a getSummary method' );
+        assert.ok( typeof uploadTester().getFeedback === 'function', 'the test has a getFeedback method' );
+        assert.ok( typeof uploadTester().labels === 'object', 'the test has a labels objects' );
+    } );
 
-    QUnit.cases([{
+    QUnit.cases.init( [ {
         title: 'no level'
     }, {
         title: 'level 0',
@@ -58,9 +59,9 @@ define([
     }, {
         title: 'level 3',
         level: 3
-    }])
-        .test('labels', function(data, assert) {
-            var labels = uploadTester({level: data.level}).labels;
+    } ] )
+        .test( 'labels', function( data, assert ) {
+            var labels = uploadTester( { level: data.level } ).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -68,73 +69,72 @@ define([
                 'uploadMax'
             ];
 
-            QUnit.expect(labelKeys.length + 1);
+            assert.expect( labelKeys.length + 1 );
 
-            assert.equal(typeof labels, 'object', 'A set of labels is returned');
-            labelKeys.forEach(function(key) {
-                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
-            });
-        });
+            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
+            labelKeys.forEach( function( key ) {
+                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
+            } );
+        } );
 
-    QUnit.test('getSummary', function(assert) {
-        var tester = uploadTester({});
+    QUnit.test( 'getSummary', function( assert ) {
+        var tester = uploadTester( {} );
         var results = {
             max: 90,
             avg: 60
         };
-        var summary = tester.getSummary(results);
+        var summary = tester.getSummary( results );
 
-        QUnit.expect(7);
+        assert.expect( 7 );
 
-        assert.equal(typeof summary, 'object', 'The method has returned the summary');
+        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
 
-        assert.equal(typeof summary.uploadMax, 'object', 'The summary contains entry for max bandwidth');
-        assert.equal(typeof summary.uploadMax.message, 'string', 'The summary contains label for max bandwidth');
-        assert.equal(summary.uploadMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth');
+        assert.equal( typeof summary.uploadMax, 'object', 'The summary contains entry for max bandwidth' );
+        assert.equal( typeof summary.uploadMax.message, 'string', 'The summary contains label for max bandwidth' );
+        assert.equal( summary.uploadMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth' );
 
-        assert.equal(typeof summary.uploadAvg, 'object', 'The summary contains entry for average bandwidth');
-        assert.equal(typeof summary.uploadAvg.message, 'string', 'The summary contains label for average bandwidth');
-        assert.equal(summary.uploadAvg.value, results.avg + ' Mbps', 'The summary contains the expected value for average bandwidth');
-    });
+        assert.equal( typeof summary.uploadAvg, 'object', 'The summary contains entry for average bandwidth' );
+        assert.equal( typeof summary.uploadAvg.message, 'string', 'The summary contains label for average bandwidth' );
+        assert.equal( summary.uploadAvg.value, results.avg + ' Mbps', 'The summary contains the expected value for average bandwidth' );
+    } );
 
-    QUnit.test('getFeedback', function(assert) {
+    QUnit.test( 'getFeedback', function( assert ) {
         var tester = uploadTester();
         var result = 1024 * 1024;
-        var status = tester.getFeedback(result);
+        var status = tester.getFeedback( result );
 
-        QUnit.expect(6);
+        assert.expect( 6 );
 
-        assert.equal(typeof status, 'object', 'The method has returned the status');
-        assert.equal(status.id, 'upload', 'The status contains the tester id');
-        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
-        assert.equal(typeof status.title, 'string', 'The status contains a title');
-        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
-        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
-    });
+        assert.equal( typeof status, 'object', 'The method has returned the status' );
+        assert.equal( status.id, 'upload', 'The status contains the tester id' );
+        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
+        assert.equal( typeof status.title, 'string', 'The status contains a title' );
+        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
+        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
+    } );
 
+    QUnit.module( 'Test' );
 
-    QUnit.module('Test');
-
-    QUnit.asyncTest('The tester runs', function(assert) {
+    QUnit.test( 'The tester runs', function( assert ) {
+        var ready = assert.async();
         var expectedSize = 100;
         var $ajax = $.ajax;
 
-        QUnit.expect(4);
+        assert.expect( 4 );
 
-        $.ajax = function (config) {
-            config.url = window.location.href.replace('test.html', 'test.json');
-            return $ajax(config);
+        $.ajax = function( config ) {
+            config.url = window.location.href.replace( 'test.html', 'test.json' );
+            return $ajax( config );
         };
 
-        uploadTester({size : expectedSize}).start(function(status, details, result) {
-            assert.ok(typeof result.avg === 'number', 'Speed is a number');
-            assert.ok(result.avg > 0, 'Speed is a positive number');
-            assert.ok(typeof result.avg === 'number', 'Loaded is a number');
-            assert.ok(result.avg > 0, 'Loaded is a positive number');
+        uploadTester( { size: expectedSize } ).start( function( status, details, result ) {
+            assert.ok( typeof result.avg === 'number', 'Speed is a number' );
+            assert.ok( result.avg > 0, 'Speed is a positive number' );
+            assert.ok( typeof result.avg === 'number', 'Loaded is a number' );
+            assert.ok( result.avg > 0, 'Loaded is a positive number' );
 
-            QUnit.start();
-        });
+            ready();
+        } );
+    } );
 
-    });
-
-});
+} );

--- a/views/js/test/tools/upload/test.js
+++ b/views/js/test/tools/upload/test.js
@@ -15,37 +15,37 @@
  *
  * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
+define([
 
     'jquery',
     'lodash',
     'taoClientDiagnostic/tools/upload/tester'
-], function(  $, _, uploadTester ) {
+], function($, _, uploadTester) {
     'use strict';
 
     // Backup/restore ajax method between each test
     var ajaxBackup;
 
-    QUnit.testStart( function() {
+    QUnit.testStart(function() {
         ajaxBackup = $.ajax;
-    } );
-    QUnit.testDone( function() {
+    });
+    QUnit.testDone(function() {
         $.ajax = ajaxBackup;
-    } );
+    });
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'The tester has the right form', function( assert ) {
-        assert.expect( 6 );
-        assert.ok( typeof uploadTester === 'function', 'The module exposes a function' );
-        assert.ok( typeof uploadTester() === 'object', 'uploadTester is a factory' );
-        assert.ok( typeof uploadTester().start === 'function', 'the test has a start method' );
-        assert.ok( typeof uploadTester().getSummary === 'function', 'the test has a getSummary method' );
-        assert.ok( typeof uploadTester().getFeedback === 'function', 'the test has a getFeedback method' );
-        assert.ok( typeof uploadTester().labels === 'object', 'the test has a labels objects' );
-    } );
+    QUnit.test('The tester has the right form', function(assert) {
+        assert.expect(6);
+        assert.ok(typeof uploadTester === 'function', 'The module exposes a function');
+        assert.ok(typeof uploadTester() === 'object', 'uploadTester is a factory');
+        assert.ok(typeof uploadTester().start === 'function', 'the test has a start method');
+        assert.ok(typeof uploadTester().getSummary === 'function', 'the test has a getSummary method');
+        assert.ok(typeof uploadTester().getFeedback === 'function', 'the test has a getFeedback method');
+        assert.ok(typeof uploadTester().labels === 'object', 'the test has a labels objects');
+    });
 
-    QUnit.cases.init( [ {
+    QUnit.cases.init([{
         title: 'no level'
     }, {
         title: 'level 0',
@@ -59,9 +59,9 @@ define( [
     }, {
         title: 'level 3',
         level: 3
-    } ] )
-        .test( 'labels', function( data, assert ) {
-            var labels = uploadTester( { level: data.level } ).labels;
+    }])
+        .test('labels', function(data, assert) {
+            var labels = uploadTester({level: data.level}).labels;
             var labelKeys = [
                 'title',
                 'status',
@@ -69,72 +69,72 @@ define( [
                 'uploadMax'
             ];
 
-            assert.expect( labelKeys.length + 1 );
+            assert.expect(labelKeys.length + 1);
 
-            assert.equal( typeof labels, 'object', 'A set of labels is returned' );
-            labelKeys.forEach( function( key ) {
-                assert.equal( typeof labels[ key ], 'string', 'The label ' + key + ' exists' );
-            } );
-        } );
+            assert.equal(typeof labels, 'object', 'A set of labels is returned');
+            labelKeys.forEach(function(key) {
+                assert.equal(typeof labels[key], 'string', 'The label ' + key + ' exists');
+            });
+        });
 
-    QUnit.test( 'getSummary', function( assert ) {
-        var tester = uploadTester( {} );
+    QUnit.test('getSummary', function(assert) {
+        var tester = uploadTester({});
         var results = {
             max: 90,
             avg: 60
         };
-        var summary = tester.getSummary( results );
+        var summary = tester.getSummary(results);
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        assert.equal( typeof summary, 'object', 'The method has returned the summary' );
+        assert.equal(typeof summary, 'object', 'The method has returned the summary');
 
-        assert.equal( typeof summary.uploadMax, 'object', 'The summary contains entry for max bandwidth' );
-        assert.equal( typeof summary.uploadMax.message, 'string', 'The summary contains label for max bandwidth' );
-        assert.equal( summary.uploadMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth' );
+        assert.equal(typeof summary.uploadMax, 'object', 'The summary contains entry for max bandwidth');
+        assert.equal(typeof summary.uploadMax.message, 'string', 'The summary contains label for max bandwidth');
+        assert.equal(summary.uploadMax.value, results.max + ' Mbps', 'The summary contains the expected value for max bandwidth');
 
-        assert.equal( typeof summary.uploadAvg, 'object', 'The summary contains entry for average bandwidth' );
-        assert.equal( typeof summary.uploadAvg.message, 'string', 'The summary contains label for average bandwidth' );
-        assert.equal( summary.uploadAvg.value, results.avg + ' Mbps', 'The summary contains the expected value for average bandwidth' );
-    } );
+        assert.equal(typeof summary.uploadAvg, 'object', 'The summary contains entry for average bandwidth');
+        assert.equal(typeof summary.uploadAvg.message, 'string', 'The summary contains label for average bandwidth');
+        assert.equal(summary.uploadAvg.value, results.avg + ' Mbps', 'The summary contains the expected value for average bandwidth');
+    });
 
-    QUnit.test( 'getFeedback', function( assert ) {
+    QUnit.test('getFeedback', function(assert) {
         var tester = uploadTester();
         var result = 1024 * 1024;
-        var status = tester.getFeedback( result );
+        var status = tester.getFeedback(result);
 
-        assert.expect( 6 );
+        assert.expect(6);
 
-        assert.equal( typeof status, 'object', 'The method has returned the status' );
-        assert.equal( status.id, 'upload', 'The status contains the tester id' );
-        assert.equal( status.percentage, 100, 'The status contains the expected percentage' );
-        assert.equal( typeof status.title, 'string', 'The status contains a title' );
-        assert.equal( typeof status.quality, 'object', 'The status contains a quality descriptor' );
-        assert.equal( typeof status.feedback, 'object', 'The status contains a feedback descriptor' );
-    } );
+        assert.equal(typeof status, 'object', 'The method has returned the status');
+        assert.equal(status.id, 'upload', 'The status contains the tester id');
+        assert.equal(status.percentage, 100, 'The status contains the expected percentage');
+        assert.equal(typeof status.title, 'string', 'The status contains a title');
+        assert.equal(typeof status.quality, 'object', 'The status contains a quality descriptor');
+        assert.equal(typeof status.feedback, 'object', 'The status contains a feedback descriptor');
+    });
 
-    QUnit.module( 'Test' );
+    QUnit.module('Test');
 
-    QUnit.test( 'The tester runs', function( assert ) {
+    QUnit.test('The tester runs', function(assert) {
         var ready = assert.async();
         var expectedSize = 100;
         var $ajax = $.ajax;
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        $.ajax = function( config ) {
-            config.url = window.location.href.replace( 'test.html', 'test.json' );
-            return $ajax( config );
+        $.ajax = function(config) {
+            config.url = window.location.href.replace('test.html', 'test.json');
+            return $ajax(config);
         };
 
-        uploadTester( { size: expectedSize } ).start( function( status, details, result ) {
-            assert.ok( typeof result.avg === 'number', 'Speed is a number' );
-            assert.ok( result.avg > 0, 'Speed is a positive number' );
-            assert.ok( typeof result.avg === 'number', 'Loaded is a number' );
-            assert.ok( result.avg > 0, 'Loaded is a positive number' );
+        uploadTester({size: expectedSize}).start(function(status, details, result) {
+            assert.ok(typeof result.avg === 'number', 'Speed is a number');
+            assert.ok(result.avg > 0, 'Speed is a positive number');
+            assert.ok(typeof result.avg === 'number', 'Loaded is a number');
+            assert.ok(result.avg > 0, 'Loaded is a positive number');
 
             ready();
-        } );
-    } );
+        });
+    });
 
-} );
+});


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs** 
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44