### PR TITLE
[TAO-8093] ACT: Client Diagnostic Tool doesn't work.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '6.0.0',
+    'version'     => '6.0.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=35.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -765,5 +765,19 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('5.0.0', '6.0.0');
+
+        if ($this->isVersion('6.0.0')) {
+            // Update clientDiag.conf.php
+            $extension = $this->getServiceManager()
+                ->get(\common_ext_ExtensionsManager::SERVICE_ID)
+                ->getExtensionById('taoClientDiagnostic');
+            $oldClientDiagConfig = $extension->getConfig('clientDiag');
+
+            $extension->setConfig('clientDiag', [
+                'diagnostic' => $oldClientDiagConfig['diagnostic'],
+            ]);
+
+            $this->setVersion('6.0.1');
+        }
     }
 }

--- a/views/js/component/diagnostic/diagnosticLoader.js
+++ b/views/js/component/diagnostic/diagnosticLoader.js
@@ -21,8 +21,9 @@ define([
     'core/moduleLoader',
     'context',
     'module',
-    'tpl!taoClientDiagnostic/component/diagnostic/tpl/component'
-], function (_, componentFactory, moduleLoader, context, module, componentTpl) {
+    'tpl!taoClientDiagnostic/component/diagnostic/tpl/component',
+    'layout/loading-bar',
+], function (_, componentFactory, moduleLoader, context, module, componentTpl, loadingBar) {
     'use strict';
     /**
      * Some default values.
@@ -69,7 +70,20 @@ define([
                             factoryConfig = componentConfig[factoryName];
                             factoryConfig.controller = componentConfig.controller;
 
-                            factory(self.getElement(), factoryConfig);
+                            var componentInstance = factory(self.getElement(), factoryConfig);
+
+                            componentInstance
+                                .on('render', function() {
+                                    if (factoryConfig.autoStart) {
+                                        this.run();
+                                    }
+                                })
+                                .on('start', function() {
+                                    loadingBar.start();
+                                })
+                                .on('end', function() {
+                                    loadingBar.stop();
+                                });
                         });
 
                         /**

--- a/views/js/controller/CompatibilityChecker/diagnostics.js
+++ b/views/js/controller/CompatibilityChecker/diagnostics.js
@@ -24,11 +24,10 @@
  */
 define([
     'jquery',
-    'layout/loading-bar',
     'ui/feedback',
     'taoClientDiagnostic/tools/message',
     'taoClientDiagnostic/component/diagnostic/diagnosticLoader'
-], function ($, loadingBar, feedback, showMessage, diagnosticFactory) {
+], function ($, feedback, showMessage, diagnosticFactory) {
     'use strict';
 
     /**
@@ -40,19 +39,7 @@ define([
 
             showMessage('#feedback-box');
 
-            diagnosticFactory($contentArea, config)
-                .on('start', function() {
-                    loadingBar.start();
-                })
-                .on('end', function() {
-                    loadingBar.stop();
-                })
-                .on('render', function() {
-                    loadingBar.stop();
-                    if (config.autoStart) {
-                        this.run();
-                    }
-                });
+            diagnosticFactory($contentArea, config);
         }
     };
 });

--- a/views/js/controller/Diagnostic/diagnostic.js
+++ b/views/js/controller/Diagnostic/diagnostic.js
@@ -55,7 +55,8 @@ define([
             var extension = $container.data('extension') || 'taoClientDiagnostic';
             var $list = $container.find('.list');
             var $panel = $('.panel');
-            var config = $container.data('config');
+            var extensionConfig = $container.data('config') || {};
+            var config = extensionConfig.diagnostic || extensionConfig;
             var indexUrl = helpers._url('index', 'Diagnostic', extension);
             var workstationUrl = helpers._url('workstation', 'DiagnosticChecker', extension);
             var buttons = [];

--- a/views/js/controller/Diagnostic/index.js
+++ b/views/js/controller/Diagnostic/index.js
@@ -118,7 +118,8 @@ define([
             var extension = $container.data('extension') || 'taoClientDiagnostic';
             var $list = $container.find('.list');
             var dataset = $container.data('set');
-            var config = $container.data('config') || {};
+            var extensionConfig = $container.data('config') || {};
+            var config = extensionConfig.diagnostic || extensionConfig;
             var installedExtension = $container.data('installedextension') || false;
             var diagnosticUrl = helpers._url('diagnostic', 'Diagnostic', extension);
             var removeUrl = helpers._url('remove', 'Diagnostic', extension);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8093
 
Fix issues related to update of taoClientDiagnostic extension config
 
#### Steps to reproduce  (for bugs)
To reproduce the issue please follow the steps described in the ticket
  
#### How to test
1.
- Install new ACT instance from develop branch
- Switch all affected extensions to PRs branches
- Update ACT instance
- Check that ltiClientDiag extension works without issues

2.
- Install new ACT instance from PRs branches
- Check that ltiClientDiag extension works without issues

  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-lti-clientdiag/pull/36
 - [ ] https://github.com/oat-sa/extension-tao-client-restrict/pull/61
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1181