### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '6.0.6',
+    'version'     => '6.1.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'tao'        => '>=35.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '6.1.0',
+    'version'     => '7.0.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'generis'    => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -33,6 +33,7 @@ return array(
     'version'     => '6.1.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
+        'generis'    => '>=12.5.0',
         'tao'        => '>=35.0.0',
         'taoQtiItem' => '>=18.0.0',
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -780,6 +780,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
         
-        $this->skip('6.0.1', '6.1.0');
+        $this->skip('6.0.1', '7.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -780,6 +780,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.0.1');
         }
         
-        $this->skip('6.0.1', '6.0.6');
+        $this->skip('6.0.1', '6.1.0');
     }
 }

--- a/test/unit/CompatibilityCheckerTest.php
+++ b/test/unit/CompatibilityCheckerTest.php
@@ -24,8 +24,9 @@ namespace oat\taoClientDiagnostic\test\unit;
 use oat\taoClientDiagnostic\model\CompatibilityChecker;
 use Sinergi\BrowserDetector\Browser;
 use Sinergi\BrowserDetector\Os;
+use oat\generis\test\TestCase;
 
-class CompatibilityCheckerTest extends \PHPUnit_Framework_TestCase
+class CompatibilityCheckerTest extends TestCase
 {
     public function testCompatibleConfigTrue()
     {

--- a/test/unit/model/authorization/AnonymousTest.php
+++ b/test/unit/model/authorization/AnonymousTest.php
@@ -22,8 +22,9 @@
 namespace oat\taoClientDiagnostic\test\unit\model\authorization;
 
 use oat\taoClientDiagnostic\model\authorization\Anonymous;
+use oat\generis\test\TestCase;
 
-class AnonymousTest extends \PHPUnit_Framework_TestCase
+class AnonymousTest extends TestCase
 {
     /**
      * @var oat\taoClientDiagnostic\model\authorization\Anonymous


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.