### PR TITLE
feat: export diagnostics to csv

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label'       => 'Browser and OS diagnostic tool',
     'description' => 'Check compatibility of the os and browser of a client',
     'license'     => 'GPL-2.0',
-    'version'     => '7.2.3',
+    'version'     => '7.3.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => array(
         'generis'    => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -815,6 +815,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('7.2.0');
         }
 
-        $this->skip('7.2.0', '7.2.3');
+        $this->skip('7.2.0', '7.3.0');
     }
 }

--- a/views/js/controller/Diagnostic/index.js
+++ b/views/js/controller/Diagnostic/index.js
@@ -33,9 +33,10 @@ define([
     'taoClientDiagnostic/tools/fingerprint/tester',
     'tpl!taoClientDiagnostic/tools/diagnostic/tpl/fingerprint',
     'tpl!taoClientDiagnostic/tools/diagnostic/tpl/details',
+    'taoClientDiagnostic/tools/csvExporter',
     'ui/datatable',
     'lib/moment-timezone.min'
-], function ($, _, __, helpers, moment, loadingBar, encode, feedback, dialog, getStatus, performancesTesterFactory, fingerprintTesterFactory, fingerprintTpl, detailsTpl) {
+], function ($, _, __, helpers, moment, loadingBar, encode, feedback, dialog, getStatus, performancesTesterFactory, fingerprintTesterFactory, fingerprintTpl, detailsTpl, csvExporter) {
     'use strict';
 
     /**
@@ -188,6 +189,19 @@ define([
                     window.location.href = diagnosticUrl;
                 }
             });
+
+            if (config.export) {
+                // tool: export csv
+                tools.push({
+                    id: 'csvExport',
+                    icon: 'export',
+                    title: __('Export CSV'),
+                    label: __('Export CSV'),
+                    action: function () {
+                        csvExporter.exportCsv(model);
+                    }
+                });
+            }
 
             if(installedExtension){
                 // tool: compatibilty via lti

--- a/views/js/tools/csvExporter.js
+++ b/views/js/tools/csvExporter.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
  */
  /**
  * @author Andrey Niahrou <andrey.niahrou@1pt.com>
@@ -70,9 +70,7 @@ define([
             // a string variable is created containing the contents of the csv file
             function arrayToCsv(data, columnDelimiter = ",", lineDelimiter = "\n") {
                 const keys = Object.keys(data[0]);
-                let result = "";
-                result += keys.join(columnDelimiter);
-                result += lineDelimiter;
+                let result = `${keys.join(columnDelimiter)}${lineDelimiter}`;
                 data.forEach(item => {
                     let ctr = 0;
                     keys.forEach(key => {
@@ -91,13 +89,15 @@ define([
             function downloadFile(content, filename, type) {
                 const blob = new Blob([content], {type: type});
                 const url = URL.createObjectURL(blob);
-                const link = $('<a></a>')
+                let link = $('<a></a>')
                     .attr('download', filename)
                     .attr('href', url)
                     .get(0)
                     .click();
 
                 URL.revokeObjectURL(url);
+
+                link = null;
             }
 
             loadingBar.start();

--- a/views/js/tools/csvExporter.js
+++ b/views/js/tools/csvExporter.js
@@ -1,0 +1,115 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA ;
+ */
+ /**
+ * @author Andrey Niahrou <andrey.niahrou@1pt.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'layout/loading-bar',
+    'helpers',
+], function ($, _, __, loadingBar, helpers) {
+    'use strict';
+
+    /**
+     * The CSS scope
+     * @type {String}
+     */
+    const cssScope = '.diagnostic-index';
+
+    /**
+     * Export diagnostics to Csv
+     * @param {Array} model - data presentation model
+     * @type {Object}
+     */
+    const csvExporter = {
+        // exporting all diagnostics
+        exportCsv: function exportCsv(model) {
+            const $container = $(cssScope);
+            const extension = $container.data('extension') || 'taoClientDiagnostic';
+            const serviceUrl = helpers._url('diagnosticData', 'Diagnostic', extension);
+
+            // wrapper for get request
+            function getRequest(url, data) {
+                return $.ajax({
+                    url: url,
+                    data: data,
+                    error: () => {
+                        loadingBar.stop();
+                    }
+                });
+            }
+
+            // filtering and transforming diagnostic data according to the model
+            function mappingDiagnosticsData(diagnostics) {
+                return diagnostics.map(diagnostic => {
+                    const result = {};
+                    _.forEach(model, field => {
+                        result[field.id] = field.transform ? field.transform(diagnostic[field.id], diagnostic) : diagnostic[field.id];
+                    });
+                    return result;
+                });
+            }
+
+            // a string variable is created containing the contents of the csv file
+            function arrayToCsv(data, columnDelimiter = ",", lineDelimiter = "\n") {
+                const keys = Object.keys(data[0]);
+                let result = "";
+                result += keys.join(columnDelimiter);
+                result += lineDelimiter;
+                data.forEach(item => {
+                    let ctr = 0;
+                    keys.forEach(key => {
+                        if (ctr > 0) {
+                            result += columnDelimiter
+                        }
+                        result += typeof item[key] === "string" && item[key].includes(columnDelimiter) ? `"${item[key]}"` : item[key];
+                        ctr++
+                    });
+                    result += lineDelimiter
+                });
+                return result
+            }
+
+            // file download from content
+            function downloadFile(content, filename, type) {
+                const blob = new Blob([content], {type: type});
+                const url = URL.createObjectURL(blob);
+                const link = $('<a></a>')
+                    .attr('download', filename)
+                    .attr('href', url)
+                    .get(0)
+                    .click();
+
+                URL.revokeObjectURL(url);
+            }
+
+            loadingBar.start();
+            getRequest(serviceUrl, {rows: Number.MAX_SAFE_INTEGER})
+                .done(response => {
+                    const mappedData = mappingDiagnosticsData(response.data);
+                    let csvContent = arrayToCsv(mappedData);
+                    downloadFile(csvContent, __('diagnostics.csv'), 'text/csv');
+                    loadingBar.stop();
+                });
+        }
+    };
+
+    return csvExporter;
+});

--- a/views/js/tools/csvExporter.js
+++ b/views/js/tools/csvExporter.js
@@ -89,8 +89,8 @@ define([
             function downloadFile(content, filename, type) {
                 const blob = new Blob([content], {type: type});
                 const url = URL.createObjectURL(blob);
-                let link = $('<a></a>')
-                    .attr('download', filename)
+                let link = $('<a></a>');
+                link.attr('download', filename)
                     .attr('href', url)
                     .get(0)
                     .click();


### PR DESCRIPTION
Related to task:
https://github.com/oat-sa/extension-tao-nec/pull/21

Description:
Export client diagnostics to csv file

How to test:
go to the client diagnostics page "/taoClientDiagnostic/Diagnostic/index" and click button 'export csv'