### PR TITLE
feat: update os/browser compatibility list

### DIFF
--- a/include/compatibility.json
+++ b/include/compatibility.json
@@ -1,67 +1,21 @@
 [
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.13", "browser" : "Firefox", "versions" : [45]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.13", "browser" : "Chrome", "versions" : [48]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.13", "browser" : "Safari", "versions" : [10]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "", "browser" : "Firefox", "versions" : [84]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "", "browser" : "Chrome", "versions" : [87]},
+    {"compatible" : 1, "os" : "OS X", "osVersion" : "", "browser" : "Safari", "versions" : [13]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Firefox", "versions" : [45]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Chrome", "versions" : [48]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.12", "browser" : "Safari", "versions" : [10]},
+    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Firefox", "versions" : [84]},
+    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Chrome", "versions" : [87]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Firefox", "versions" : [40]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Chrome", "versions" : [45]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.11", "browser" : "Safari", "versions" : [9]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "", "browser" : "Firefox", "versions" : [84]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "", "browser" : "Chrome", "versions" : [87]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "", "browser" : "Edge", "versions" : [87]},
+    {"compatible" : 1, "os" : "Windows", "osVersion" : "", "browser" : "Internet Explorer", "versions" : [11]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Firefox", "versions" : [34]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.10", "browser" : "Safari", "versions" : [8]},
+    {"compatible" : 1, "os" : "Android", "osVersion" : "", "browser" : "Chrome", "versions" : [88]},
+    {"compatible" : 1, "os" : "Android", "osVersion" : "", "browser" : "Firefox", "versions" : [85]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.9", "browser" : "Safari", "versions" : [7]},
+    {"compatible" : 1, "os" : "iOS", "osVersion" : "", "browser" : "Safari", "versions" : [13]},
+    {"compatible" : 1, "os" : "iOS", "osVersion" : "", "browser" : "Safari", "versions" : [14]},
 
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 34]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "OS X", "osVersion" : "10.7", "browser" : "Safari", "versions" : []},
-
-    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "Linux", "osVersion" : "", "browser" : "Firefox", "versions" : [31]},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Firefox", "versions" : [40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Chrome", "versions" : [45]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Internet Explorer", "versions" : [11]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "10", "browser" : "Edge", "versions" : []},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Firefox", "versions" : [27, 28, 29, 30, 36, 40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Chrome", "versions" : [33, 34, 35, 40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [11]},
-    {"compatible" : 0, "os" : "Windows", "osVersion" : "8.1", "browser" : "Internet Explorer", "versions" : [10]},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Firefox", "versions" : [35]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Chrome", "versions" : [39]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [11]},
-    {"compatible" : 0, "os" : "Windows", "osVersion" : "8", "browser" : "Internet Explorer", "versions" : [10]},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Firefox", "versions" : [34]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Chrome", "versions" : [40]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [11]},
-    {"compatible" : 0, "os" : "Windows", "osVersion" : "7", "browser" : "Internet Explorer", "versions" : [9, 10]},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Firefox", "versions" : [35]},
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "XP", "browser" : "Chrome", "versions" : [40]},
-    {"compatible" : 0, "os" : "Windows", "osVersion" : "XP", "browser" : "Internet Explorer", "versions" : [8]},
-
-    {"compatible" : 1, "os" : "Windows", "osVersion" : "Server2003", "browser" : "Firefox", "versions" : [34, 37, 40]},
-
-    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome", "versions" : [48]},
-
-    {"compatible" : 1, "os" : "iOS", "osVersion" : "10", "browser" : "Safari", "versions" : [10]},
-    {"compatible" : 1, "os" : "iOS", "osVersion" : "9", "browser" : "Safari", "versions" : [9]},
-    {"compatible" : 1, "os" : "iOS", "osVersion" : "8", "browser" : "", "versions" : []},
-    {"compatible" : 1, "os" : "iOS", "osVersion" : "7", "browser" : "Safari", "versions" : [7]},
-
-    {"compatible" : 1, "os" : "Android", "osVersion" : "7", "browser" : "Chrome", "versions" : [55]},
-    {"compatible" : 1, "os" : "Android", "osVersion" : "4.4", "browser" : "Chrome", "versions" : [34]},
-    {"compatible" : 1, "os" : "Android", "osVersion" : "4.4", "browser" : "Firefox", "versions" : [28]},
-    {"compatible" : 1, "os" : "Android", "osVersion" : "4.1", "browser" : "Chrome", "versions" : [34]},
-    {"compatible" : 1, "os" : "Android", "osVersion" : "2.4", "browser" : "", "versions" : []}
+    {"compatible" : 1, "os" : "Chrome OS", "osVersion" : "", "browser" : "Chrome", "versions" : [87]}
 ]

--- a/model/CompatibilityChecker.php
+++ b/model/CompatibilityChecker.php
@@ -78,10 +78,8 @@ class CompatibilityChecker
                     $isValid = true;
                 } else {
                     // it is valid if the version is in the array
-                    // OR if the browser is chrome or firefox and it is a newer version than those in the array
-                    $isValid = in_array($browserVersion, $rule->versions)
-                        || (in_array($rule->browser,
-                                array('Chrome', 'Firefox')) && $browserVersion > max($rule->versions));
+                    // OR if the version is newer than the maximum version in the array
+                    $isValid = in_array($browserVersion, $rule->versions) || $browserVersion > max($rule->versions);
                 }
 
                 if ($validOs && ($rule->browser === ""


### PR DESCRIPTION
Update compatibility list according to compatible browser list from here: https://oat-sa.github.io/browserslist-app-tao/
 
Related to : https://oat-sa.atlassian.net/browse/TR-1068
 
Deleted all the previous rules targeting specific OS versions. Browser is compatible if its version is either equal or greater to those in compatibility list.  

#### How to test

- Configure TAO with `taoClientDiagnostic` extension installed
- Launch compatibility tool at `YOUR_INSTANCE_URI/taoClientDiagnostic/CompatibilityChecker`
- Click on `Test system compatibility` button
- Verify that compatible browsers show message `Operating system and web browser - Compatible`
and unlisted browsers show message `Operating system and web browser - This browser is not tested.`

Browser version can be mocked in [chrome network conditions tool](https://developer.chrome.com/docs/devtools/device-mode/override-user-agent/) 

There is a throwaway environment created for testing, link is in the linked jira ticket.
 

