### PR TITLE
Fix: omit becomes omitBy with lodash 4

### DIFF
--- a/views/js/tools/getConfig.js
+++ b/views/js/tools/getConfig.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2024 (original work) Open Assessment Technologies SA ;
  */
 define(['lodash'], function(_) {
     'use strict';
@@ -26,7 +26,7 @@ define(['lodash'], function(_) {
      */
     return function getConfig(config, defaults) {
         return _(config || {})
-            .omit(value => value === null || typeof value === 'undefined')
+            .omitBy(value => value === null || typeof value === 'undefined')
             .defaults(defaults || {})
             .value();
     };


### PR DESCRIPTION
Unit test was failing:
<img width="804" alt="Screenshot 2024-05-24 at 11 24 45" src="https://github.com/oat-sa/extension-tao-clientdiag/assets/43652944/6a7bf4e6-4bff-468e-9019-26cf8fbb4686">

And CI action was failing for 4 months because of it: https://github.com/oat-sa/extension-tao-clientdiag/actions/workflows/continuous-integration.yaml

---

When lodash was upgraded from 2 -> 4, `_.omit(function)` became `_.omitBy(function)`. [Docs](https://lodash.com/docs/4.17.15#omitBy).

Test now passes again, with `npx grunt connect:test taoclientdiagnostictest`