### PR TITLE
Fix/LSI-5044/Runtime-error-in-diagnostic 

### DIFF
--- a/views/js/tools/diagnostic/diagnostic.js
+++ b/views/js/tools/diagnostic/diagnostic.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2024 (original work) Open Assessment Technologies SA ;
  */
 define([
     'jquery',
@@ -40,7 +40,7 @@ define([
     'tpl!taoClientDiagnostic/tools/diagnostic/tpl/feedback',
     'tpl!taoClientDiagnostic/tools/diagnostic/tpl/quality-bar',
     'css!taoClientDiagnosticCss/diagnostics'
-], function(
+], function (
     $,
     _,
     __,
@@ -418,7 +418,7 @@ define([
                     // launch each testers in series, then display the results
                     async.series(testers, () => {
                         // pick the lowest percentage as the main score
-                        const total = _.minBy(scores, 'globalPercentage');
+                        const total = _.minBy(Object.values(scores), 'globalPercentage');
 
                         // get a status according to the main score
                         const status = getStatus(total.globalPercentage, _thresholds);
@@ -631,7 +631,7 @@ define([
                      * @private
                      */
                     function toggleFields(state) {
-                        _.forEach(fields, function(fieldName) {
+                        _.forEach(fields, function (fieldName) {
                             toggleControl(fieldName, state);
                         });
                     }
@@ -696,9 +696,7 @@ define([
                             {}
                         );
 
-                        this.changeStatus(__('Getting school name...'))
-                            .cleanUp()
-                            .disable();
+                        this.changeStatus(__('Getting school name...')).cleanUp().disable();
 
                         if (_.isFunction(validate)) {
                             validate(values)


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/LSI-5044

### Summary

Fix a runtime error occurring when launching the diagnostic
![image](https://github.com/user-attachments/assets/a15280c8-fdb8-48e3-8471-6ca8891b55bb)


### Details

After the upgrade to lodash v4, some calls were not updated, and we kept a wrong use of `_.minBy()`, which expects an array and not an object.

### How to test
- checkout the branch: `git checkout -t origin/fix/LSI-5044/runtime-error-in-diagnostic`
- install the diagnostic tool
- open the diagnostic at `https://HOSTNAME/taoClientDiagnostic/CompatibilityChecker/index`
- launch the diagnostic
- it must complete without error