### PR TITLE
Fix/LSI-5111/Fix-broken-browser-check-in-safari

### DIFF
--- a/views/js/tools/browser/tester.js
+++ b/views/js/tools/browser/tester.js
@@ -136,7 +136,7 @@ define([
                     // Some useful traversal algorithms are needed and they don't have polyfill in our bundles.
                     // The versions come with an inconsistent format and they need to be processed upfront.
                     return _(versions)
-                        .map(version => version.split('-'))
+                        .map(version => version.toString().split('-'))
                         .flatten()
                         .value()
                         .some(version => currentVersion.localeCompare(version, void 0, { numeric: true }) >= 0);


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/LSI-5111

### Summary

Fix a runtime error occurring during the browser compatibility check
![image](https://github.com/user-attachments/assets/43619fd0-84e6-4178-b40e-48e6f0c81ab3)

### Details

Unlike the other browsers (checked at least on Chrome, Chromium, Firefox) - version returned by BE check for Safari is a number. And `Number` type doesn't have `.split()` function.

### How to test
- checkout the branch: `git checkout -t origin/fix/LSI-5111/fix-broken-browser-check-in-safari`
- install the diagnostic tool
- open the diagnostic at `https://HOSTNAME/taoClientDiagnostic/CompatibilityChecker/index`
- launch the diagnostic
- it must complete without hanging on browser check